### PR TITLE
Fix: problem with Select2 v4

### DIFF
--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -336,14 +336,14 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
   enable: function() {
     if(!this.always_disabled) {
       this.input.disabled = false;
-      if(this.select2) this.select2.select2("enable",true);
+      if(this.select2) this.select2.prop("disabled",false);
     }
     this._super();
   },
   disable: function(always_disabled) {
     if(always_disabled) this.always_disabled = true;
     this.input.disabled = true;
-    if(this.select2) this.select2.select2("enable",false);
+    if(this.select2) this.select2.prop("disabled",true);
     this._super();
   },
   destroy: function() {


### PR DESCRIPTION
Fixed issue when using Select2 version 4 where after closing the properties popup all select2s are permanently disabled. This probably breaks compability with older versions of Select2, but I couldn't figure out a way to check the version.