### PR TITLE
Select2 v4 support with backwards compatibility.

### DIFF
--- a/src/editors/multiselect.js
+++ b/src/editors/multiselect.js
@@ -99,6 +99,7 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
         var options = window.jQuery.extend({},JSONEditor.plugins.select2);
         if(this.schema.options && this.schema.options.select2_options) options = $extend(options,this.schema.options.select2_options);
         this.select2 = window.jQuery(this.input).select2(options);
+        this.select2v4 = this.select.hasOwnProperty("amd");
         var self = this;
         this.select2.on('select2-blur',function() {
             var val =self.select2.select2('val');
@@ -150,7 +151,12 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
       if(sanitized !== value[i]) changed = true;
     }
     this.value = new_value;
-    if(this.select2) this.select2.select2('val',this.value);
+    if(this.select2) {
+      if(this.select2v4)
+        this.select2.val(this.value).trigger("change"); 
+      else
+        this.select2.select2('val',this.value);
+    }
     return changed;
   },
   sanitize: function(value) {
@@ -175,7 +181,12 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
           this.inputs[i].disabled = false;
         }
       }
-      if(this.select2) this.select2.select2("enable",true);
+      if(this.select2) {
+        if(this.select2v4)
+          this.select2.prop("disabled",false);
+        else
+          this.select2.select2("enable",true);
+      }
       this._super();
     }
   },
@@ -190,7 +201,12 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
         this.inputs[i].disabled = true;
       }
     }
-    if(this.select2) this.select2.select2("enable",false);
+    if(this.select2) {
+      if(this.select2v4)
+        this.select2.prop("disabled",true);
+      else
+        this.select2.select2("enable",false);
+    }
     this._super();
   },
   destroy: function() {

--- a/src/editors/multiselect.js
+++ b/src/editors/multiselect.js
@@ -99,7 +99,7 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
         var options = window.jQuery.extend({},JSONEditor.plugins.select2);
         if(this.schema.options && this.schema.options.select2_options) options = $extend(options,this.schema.options.select2_options);
         this.select2 = window.jQuery(this.input).select2(options);
-        this.select2v4 = this.select.hasOwnProperty("amd");
+        this.select2v4 = this.select2.hasOwnProperty("amd");
         var self = this;
         this.select2.on('select2-blur',function() {
             var val =self.select2.select2('val');

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -336,14 +336,14 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
   enable: function() {
     if(!this.always_disabled) {
       this.input.disabled = false;
-      if(this.select2) this.select2.select2("enable",true);
+      if(this.select2) this.select2.prop("disabled",false);
     }
     this._super();
   },
   disable: function(always_disabled) {
     if(always_disabled) this.always_disabled = true;
     this.input.disabled = true;
-    if(this.select2) this.select2.select2("enable",false);
+    if(this.select2) this.select2.prop("disabled",true);
     this._super();
   },
   destroy: function() {

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -13,7 +13,12 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
     }
 
     this.input.value = this.enum_options[this.enum_values.indexOf(sanitized)];
-    if(this.select2) this.select2.select2('val',this.input.value);
+    if(this.select2) {
+      if(this.select2v4)
+        this.select2.val(this.input.value).trigger("change"); 
+      else
+        this.select2.select2('val',this.input.value);
+    }
     this.value = sanitized;
     this.onChange();
     this.change();
@@ -207,6 +212,7 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
       var options = $extend({},JSONEditor.plugins.select2);
       if(this.schema.options && this.schema.options.select2_options) options = $extend(options,this.schema.options.select2_options);
       this.select2 = window.jQuery(this.input).select2(options);
+      this.select2v4 = this.select2.select2.hasOwnProperty("amd");
       var self = this;
       this.select2.on('select2-blur',function() {
         self.input.value = self.select2.select2('val');
@@ -336,14 +342,24 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
   enable: function() {
     if(!this.always_disabled) {
       this.input.disabled = false;
-      if(this.select2) this.select2.prop("disabled",false);
+      if(this.select2) {
+        if(this.select2v4)
+          this.select2.prop("disabled",false);
+        else
+          this.select2.select2("enable",true);
+      }
     }
     this._super();
   },
   disable: function(always_disabled) {
     if(always_disabled) this.always_disabled = true;
     this.input.disabled = true;
-    if(this.select2) this.select2.prop("disabled",true);
+    if(this.select2) {
+      if(this.select2v4)
+        this.select2.prop("disabled",true);
+      else
+        this.select2.select2("enable",false);
+    }
     this._super();
   },
   destroy: function() {


### PR DESCRIPTION
Fixed issue when using Select2 version 4 where after closing the properties popup all select2s are permanently disabled. This detects if Select2 is version 4, and if so uses it's new API for val and disabled. Otherwise uses the old implementation.