### PR TITLE
Allow required to overwrite required_by_default

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -23,33 +23,17 @@ JSONEditor.Validator = Class.extend({
      * Type Agnostic Validation
      */
 
-    // Version 3 `required`
-    if(schema.required && schema.required === true) {
-      if(typeof value === "undefined") {
-        errors.push({
-          path: path,
-          property: 'required',
-          message: this.translate("error_notset")
-        });
-
-        // Can't do any more validation at this point
-        return errors;
-      }
-    }
-    // Value not defined
-    else if(typeof value === "undefined") {
-      // If required_by_default is set, all fields are required
-      if(this.jsoneditor.options.required_by_default) {
+    // Version 3 `required` and `required_by_default`
+    if(typeof value === "undefined") {
+      if((typeof schema.required !== "undefined" && schema.required === true) || (typeof schema.required === "undefined" && this.jsoneditor.options.required_by_default === true)) {
         errors.push({
           path: path,
           property: 'required',
           message: this.translate("error_notset")
         });
       }
-      // Not required, no further validation needed
-      else {
-        return errors;
-      }
+      
+      return errors;
     }
 
     // `enum`
@@ -442,7 +426,7 @@ JSONEditor.Validator = Class.extend({
       }
 
       // Version 4 `required`
-      if(schema.required && Array.isArray(schema.required)) {
+      if(typeof schema.required !== "undefined" && Array.isArray(schema.required)) {
         for(i=0; i<schema.required.length; i++) {
           if(typeof value[schema.required[i]] === "undefined") {
             errors.push({
@@ -457,10 +441,17 @@ JSONEditor.Validator = Class.extend({
       // `properties`
       var validated_properties = {};
       if(schema.properties) {
-        for(i in schema.properties) {
-          if(!schema.properties.hasOwnProperty(i)) continue;
-          validated_properties[i] = true;
-          errors = errors.concat(this._validateSchema(schema.properties[i],value[i],path+'.'+i));
+        if(typeof schema.required !== "undefined" && Array.isArray(schema.required)) {
+          for(i of schema.required) {
+            validated_properties[i] = true;
+            errors = errors.concat(this._validateSchema(schema.properties[i],value[i],path+'.'+i));
+          }
+        } else {
+          for(i in schema.properties) {
+            if(!schema.properties.hasOwnProperty(i)) continue;
+            validated_properties[i] = true;
+            errors = errors.concat(this._validateSchema(schema.properties[i],value[i],path+'.'+i));
+          }
         }
       }
 
@@ -468,7 +459,6 @@ JSONEditor.Validator = Class.extend({
       if(schema.patternProperties) {
         for(i in schema.patternProperties) {
           if(!schema.patternProperties.hasOwnProperty(i)) continue;
-
           var regex = new RegExp(i);
 
           // Check which properties match

--- a/src/validator.js
+++ b/src/validator.js
@@ -443,9 +443,9 @@ JSONEditor.Validator = Class.extend({
       if(schema.properties) {
         if(typeof schema.required !== "undefined" && Array.isArray(schema.required)) {
           for(i=0; i<schema.required.length; i++) {
-            prop = schema.required[i];
-            validated_properties[prop] = true;
-            errors = errors.concat(this._validateSchema(schema.properties[prop],value[prop],path+'.'+prop));
+            var property = schema.required[i];
+            validated_properties[property] = true;
+            errors = errors.concat(this._validateSchema(schema.properties[property],value[property],path+'.'+property));
           }
         } else {
           for(i in schema.properties) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -442,9 +442,10 @@ JSONEditor.Validator = Class.extend({
       var validated_properties = {};
       if(schema.properties) {
         if(typeof schema.required !== "undefined" && Array.isArray(schema.required)) {
-          for(i of schema.required) {
-            validated_properties[i] = true;
-            errors = errors.concat(this._validateSchema(schema.properties[i],value[i],path+'.'+i));
+          for(i=0; i<schema.required.length; i++) {
+            prop = schema.required[i];
+            validated_properties[prop] = true;
+            errors = errors.concat(this._validateSchema(schema.properties[prop],value[prop],path+'.'+prop));
           }
         } else {
           for(i in schema.properties) {


### PR DESCRIPTION
In the README.md file, the `required_by_default` option is described as:

> If `true`, all schemas that don't explicitly set the `required` property will be required.

But schemas that explicitly set the `required` property do not overwrite the `required_by_default` option as advertised, so they are always required (even with `required = false` using JSON Schema 3 syntax or `required = []` using JSON Schema 4 syntax).

The issue can be demonstrated with this code snippet which does not pass validation:

```
var element = document.querySelector("#editor");
var options = {
  "required_by_default": true,
  "schema": {
    "type": "object",
    "properties": {
      "a": {"type": "string"},
      "b": {"type": "string"}
    },
    "required": ["a"]  // should overwrite `required_by_default` but does not
  }
};
var editor = new JSONEditor(element, options);
var errors = editor.validate({"a": "foobar"});

if (errors.length) {
  window.console.log(errors);
} else {
  window.console.log("OK");
}
```