### PR TITLE
required boolean checkboxes with error messages

### DIFF
--- a/src/editors/checkbox.js
+++ b/src/editors/checkbox.js
@@ -59,5 +59,30 @@ JSONEditor.defaults.editors.checkbox = JSONEditor.AbstractEditor.extend({
     if(this.description && this.description.parentNode) this.description.parentNode.removeChild(this.description);
     if(this.input && this.input.parentNode) this.input.parentNode.removeChild(this.input);
     this._super();
-  }
+  },
+	showValidationErrors: function (errors) {
+		var self = this;
+
+		if (this.jsoneditor.options.show_errors === "always") {
+		}
+		else if (!this.is_dirty && this.previous_error_setting === this.jsoneditor.options.show_errors) return;
+
+		this.previous_error_setting = this.jsoneditor.options.show_errors;
+
+		var messages = [];
+		$each(errors, function (i, error) {
+			if (error.path === self.path) {
+				messages.push(error.message);
+			}
+		});
+
+		this.input.controlgroup = this.control;
+
+		if (messages.length) {
+			this.theme.addInputError(this.input, messages.join('. ') + '.');
+		}
+		else {
+			this.theme.removeInputError(this.input);
+		}
+	}
 });

--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -136,7 +136,8 @@ JSONEditor.defaults.themes.bootstrap3 = JSONEditor.AbstractTheme.extend({
         this.queuedInputErrorText = text;
         return; 
     }
-    input.controlgroup.className += ' has-error';
+	  input.controlgroup.className = input.controlgroup.className.replace(/\s?has-error/g,'');
+	  input.controlgroup.className += ' has-error';
     if(!input.errmsg) {
       input.errmsg = document.createElement('p');
       input.errmsg.className = 'help-block errormsg';

--- a/src/validator.js
+++ b/src/validator.js
@@ -51,6 +51,23 @@ JSONEditor.Validator = Class.extend({
       }
     }
 
+		// 'required boolean'
+	  if (schema.type === 'boolean' && schema.required === true) {
+		  valid = false;
+
+		  if (value === true) {
+			  valid = schema.required;
+		  }
+
+		  if (!valid) {
+			  errors.push({
+				  path: path,
+				  property: 'required',
+				  message: this.translate("error_required")
+			  });
+		  }
+	  }
+
     // `extends` (version 3)
     if(schema["extends"]) {
       for(i=0; i<schema["extends"].length; i++) {


### PR DESCRIPTION
Example:
{
	"agree": {
		"type": "boolean",
		"format": "checkbox",
		"required": true
	}
}

The rule applies only if the schema has both:
"type" : "boolean",
"required": true