### PR TITLE
Fixes/checkbox validation

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -442,8 +442,13 @@ JSONEditor.AbstractEditor = Class.extend({
     this.parent = null;
   },
   getDefault: function() {
-    if(this.schema["default"]) return this.schema["default"];
-    if(this.schema["enum"]) return this.schema["enum"][0];
+    if (typeof this.schema["default"] !== 'undefined') {
+      return this.schema["default"];
+    }
+
+    if (typeof this.schema["enum"] !== 'undefined') {
+      return this.schema["enum"][0];
+    }
     
     var type = this.schema.type || this.schema.oneOf;
     if(type && Array.isArray(type)) type = type[0];

--- a/src/editors/checkbox.js
+++ b/src/editors/checkbox.js
@@ -59,5 +59,32 @@ JSONEditor.defaults.editors.checkbox = JSONEditor.AbstractEditor.extend({
     if(this.description && this.description.parentNode) this.description.parentNode.removeChild(this.description);
     if(this.input && this.input.parentNode) this.input.parentNode.removeChild(this.input);
     this._super();
+  },
+  showValidationErrors: function (errors) {
+    var self = this;
+
+    if (this.jsoneditor.options.show_errors === "always") {}
+
+    else if (!this.is_dirty && this.previous_error_setting === this.jsoneditor.options.show_errors) {
+      return;
+    }
+
+    this.previous_error_setting = this.jsoneditor.options.show_errors;
+
+    var messages = [];
+    $each(errors, function (i, error) {
+      if (error.path === self.path) {
+        messages.push(error.message);
+      }
+    });
+
+    this.input.controlgroup = this.control;
+
+    if (messages.length) {
+      this.theme.addInputError(this.input, messages.join('. ') + '.');
+    }
+    else {
+      this.theme.removeInputError(this.input);
+    }
   }
 });

--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -136,6 +136,7 @@ JSONEditor.defaults.themes.bootstrap3 = JSONEditor.AbstractTheme.extend({
         this.queuedInputErrorText = text;
         return; 
     }
+    input.controlgroup.className = input.controlgroup.className.replace(/\s?has-error/g,'');
     input.controlgroup.className += ' has-error';
     if(!input.errmsg) {
       input.errmsg = document.createElement('p');


### PR DESCRIPTION
- src/editor:
problem: when default and enum are set in a schema, if the default value is false (or falsy) the schema will use the first element in the enum array.
solution: Improved the conditionals in the "getDefault" method. now checks if default is defined.

- src/editors/checkbox.js
problem: checkboxes not displaying validation error messages 
solution: added "showValidationErrors" method (simil string editor)


-src/themes/bootstrap3.js
problem: the class 'has-errors' where added multiple times.
solution: clear the class before adding the class.