### PR TITLE
Update theme.js

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -191,6 +191,13 @@ JSONEditor.AbstractTheme = Class.extend({
     el.setAttribute('step',step);
     return el;
   },
+  getNumberInput: function(min,max,step) {
+    var el = this.getFormInputField('number');
+    el.setAttribute('min',min);
+    el.setAttribute('max',max);
+    el.setAttribute('step',step);
+    return el;
+  },
   getFormInputField: function(type) {
     var el = document.createElement('input');
     el.setAttribute('type',type);


### PR DESCRIPTION
Support of input control for number with min, max and steps attributes. Unlike range attribute it will add up-down button in text box.
Example:
"Properties":{
	numberProperty:{
		"type":"number",
		"format":"number",
		"maximum":"100",
		"minimum":"1",
		"step":1
	}
}