### PR TITLE
Added a CDN link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ Check out an interactive demo (demo.html): https://json-editor.github.io/json-ed
 Install
 -----------------
 
+Install package
+  
     npm install @json-editor/json-editor
+  
+Using a CDN
+  
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
 
 Requirements
 -----------------


### PR DESCRIPTION
I thought it would be good to have a cdn link on the readme since it isn't immediately obvious that the dist folder is only on the release branches.

I added a jsdelivr link, but could be changed to another cdn if that isnt preferred