### PR TITLE
add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "editor"
   ],
   "scripts": {
+    "prepare": "grunt",
     "build": "npm install && grunt",
     "start": "grunt watch",
     "test": "grunt test",


### PR DESCRIPTION
allows for:

 ```
 "dependencies": {
    "@json-editor/json-editor": "git+https://github.com/json-editor/json-editor.git",
...
  },

```
to actually work. 

See: https://docs.npmjs.com/misc/scripts#description

Note that I discovered [breaking changes in the pull request I made earlier](https://github.com/json-editor/json-editor/pull/72)... will try to fix them.