### PR TITLE
Call event handlers with context

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -154,7 +154,7 @@ JSONEditor.prototype = {
   trigger: function(event) {
     if(this.callbacks && this.callbacks[event] && this.callbacks[event].length) {
       for(var i=0; i<this.callbacks[event].length; i++) {
-        this.callbacks[event][i]();
+        this.callbacks[event][i].apply(this, []);
       }
     }
     


### PR DESCRIPTION
json-editor doesn't give the registered event handlers context for what editor instance changed.
Usually this isn't a problem if a reference to the json-editor instance is preserved, e.g.
```
var editor = new JSONEditor(container, {});
jQuery(container).data('editor', editor);
editor.on('change',function() {
  var value = jQuery(container).data('editor').getValue();
});
```
But in the above case if json-editor rendered text input element receives a change and container element is removed from DOM without the text input losing focus, then json-editor does call trigger('change') and jQuery(container).data('editor') is undefined.
With the proposed change it's possible to do `this.getValue()` in the event handler without issues.
