### PR TITLE
bugfix: missing null value condition

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -950,7 +950,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     if(this.jsoneditor.options.remove_empty_properties || this.options.remove_empty_properties) {
       for (var i in result) {
         if (result.hasOwnProperty(i)) {
-          if (typeof result[i] === 'undefined' || result[i] === '' || Object.keys(result[i]).length == 0 && result[i].constructor == Object) delete result[i];
+          if (typeof result[i] === 'undefined' || result[i] === '' || result[i] === null || Object.keys(result[i]).length == 0 && result[i].constructor == Object) delete result[i];
         }
       }
     }


### PR DESCRIPTION
I have encountered a bug as screenshot when I was using object properities.
<img width="1440" alt="2018-06-27 5 10 03" src="https://user-images.githubusercontent.com/335311/41964617-0c33a584-7a2d-11e8-9451-158de9c0d879.png">

I found that it's caused by a missing condition for `null` value in `getValue()`.
```js
if (typeof result[i] === 'undefined' || result[i] === '' || Object.keys(result[i]).length == 0 && result[i].constructor == Object) delete result[i];
```