### PR TITLE
bug fix: select editor onInputChange: val should be in enum_values

### DIFF
--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -192,11 +192,11 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
 
     var new_val;
     // Invalid option, use first option instead
-    if(this.enum_options.indexOf(val) === -1) {
+    if(this.enum_values.indexOf(val) === -1) {
       new_val = this.enum_values[0];
     }
     else {
-      new_val = this.enum_values[this.enum_options.indexOf(val)];
+      new_val = this.enum_values[this.enum_values.indexOf(val)];
     }
 
     // If valid hasn't changed


### PR DESCRIPTION
related issue: https://github.com/json-editor/json-editor/issues/112

In select editor, onInputChange function, the val is typecasted, so it should be compared against values in enum_values instead of enum_options.

