### PR TITLE
relative filepaths + extended testsuite

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -387,7 +387,7 @@ JSONEditor.prototype = {
       waiting++;
 
       var fetchUrl=url;
-      if( fileBase!=url.substr(0,fileBase.length) && "http"!=url.substr(0,4)) fetchUrl=fileBase+url;
+      if( fileBase!=url.substr(0,fileBase.length) && "http"!=url.substr(0,4) && "/"!=url.substr(0,1)) fetchUrl=fileBase+url;
 
       var r = new XMLHttpRequest();
       r.open("GET", fetchUrl, true);

--- a/src/core.js
+++ b/src/core.js
@@ -359,15 +359,27 @@ JSONEditor.prototype = {
         merge_refs(this._getExternalRefs(schema[i]));
       }
     }
-    
+
     return refs;
   },
-  _loadExternalRefs: function(schema, callback) {
+  _getFileBase: function() {
+    var fileBase = this.options.ajaxBase;
+    if (typeof fileBase === 'undefined') {
+      fileBase = this._getFileBaseFromFileLocation(document.location.toString());
+    }
+    return fileBase;
+  },
+  _getFileBaseFromFileLocation: function(fileLocationString) {
+    var pathItems = fileLocationString.split("/");
+    pathItems.pop();
+    return pathItems.join("/")+"/";
+  },
+  _loadExternalRefs: function(schema, callback, fileBase) {
+    fileBase = fileBase || this._getFileBase();
     var self = this;
     var refs = this._getExternalRefs(schema);
-    
     var done = 0, waiting = 0, callback_fired = false;
-    
+
     $each(refs,function(url) {
       if(self.refs[url]) return;
       if(!self.options.ajax) throw "Must set ajax option to true to load external ref "+url;
@@ -375,13 +387,13 @@ JSONEditor.prototype = {
       waiting++;
 
       var fetchUrl=url;
-      if( self.options.ajaxBase && self.options.ajaxBase!=url.substr(0,self.options.ajaxBase.length) && "http"!=url.substr(0,4)) fetchUrl=self.options.ajaxBase+url;
+      if( fileBase!=url.substr(0,fileBase.length) && "http"!=url.substr(0,4)) fetchUrl=fileBase+url;
 
-      var r = new XMLHttpRequest(); 
+      var r = new XMLHttpRequest();
       r.open("GET", fetchUrl, true);
       if(self.options.ajaxCredentials) r.withCredentials=self.options.ajaxCredentials;
       r.onreadystatechange = function () {
-        if (r.readyState != 4) return; 
+        if (r.readyState != 4) return;
         // Request succeeded
         if(r.status === 200) {
           var response;
@@ -401,7 +413,7 @@ JSONEditor.prototype = {
               callback_fired = true;
               callback();
             }
-          });
+          }, self._getFileBaseFromFileLocation(fetchUrl));
         }
         // Request failed
         else {

--- a/tests/codeceptjs/editors/validation_test.js
+++ b/tests/codeceptjs/editors/validation_test.js
@@ -1,0 +1,12 @@
+// Note: validation.html has its own way of testing; this test simply tests if the output of that test conforms to the expected output
+
+Feature('Validations');
+
+Scenario('test validations in validation.html', (I) => {
+    I.amOnPage('validation.html');
+    var numberOfTestItemsExpected = 129;
+    I.waitForElement("#output div:nth-child("+numberOfTestItemsExpected+")", 10);
+    I.seeNumberOfElements("#output div", numberOfTestItemsExpected);
+    I.see("success");
+    I.dontSee('Fail');
+});

--- a/tests/pages/validation.html
+++ b/tests/pages/validation.html
@@ -556,7 +556,7 @@
                         pattern: "^/dev/[^/]+(/[^/]+)*$"
                     },
                     external: {
-                        "$ref": "string.json"
+                        "$ref": "../fixtures/string.json"
                     }
                 }
             },
@@ -629,7 +629,7 @@
             schema: {
                 type: "object",
                 properties: {
-                    "/": { $ref: 'string.json' }
+                    "/": { $ref: '../fixtures/string.json' }
                 }
             },
             valid: [
@@ -647,9 +647,9 @@
             schema: {
                 type: "object",
                 properties: {
-                    "recursive": { $ref: 'recursive.json' },
+                    "recursive": { $ref: '../fixtures/recursive.json' },
                     "string": {
-                        $ref: "string.json"
+                        $ref: "../fixtures/string.json"
                     }
                 }
             },
@@ -766,9 +766,10 @@
                   var result = editor.validate(value);
                   if(result.length) {
                       console.error(num,'valid',j,JSON.stringify(result,null,2));
-                      $("#output").append("<div><strong>"+i+" test "+j+"</strong>:: Expected: [], Actual: "+JSON.stringify(result)+"</div>");
+                      $("#output").append("<div><strong>"+i+" test "+j+"</strong>: Fail. Expected: [], Actual: "+JSON.stringify(result)+"</div>");
                   }
                   else {
+                      $("#output").append("<div><strong>"+i+" test "+j+"</strong>: Test for valid is success</div>");
                       console.log(num,'valid',j);
                   }
                 }
@@ -783,8 +784,7 @@
                   var result = editor.validate(value);
                   if(!result.length) {
                       console.error(num,'invalid',j,JSON.stringify(result,null,2));
-                      $("#output").append("<div><strong>"+i+" test "+j+"</strong>:: Expected: errors, Actual: []</div>");
-
+                      $("#output").append("<div><strong>"+i+" test "+j+"</strong>: Fail. Expected: errors, Actual: []</div>");
                   }
                   else {
                       var errors = [];
@@ -792,7 +792,7 @@
                           errors.push(error.path+": "+error.message);
                       });
                       if(errors.length === 1) errors = errors[0];
-
+                      $("#output").append("<div><strong>"+i+" test "+j+"</strong>: Test for invalid is success</div>");
                       console.log(num,'invalid',j,JSON.stringify(errors,null,2));
                   }
                 }


### PR DESCRIPTION
* added support for relative file paths
* added validation.html to test suite (implicitly tests relative file paths)

In an ideal world the tests in validation.html would be converted to tests native to the test-suite, but recreating the 129 validation-tests isn't a trivial task. I made sure the successes were shown as well and created a codecept test for it.

The reason for testing with validation.html was that I had issues with relative file paths with external references and validations.html by accident referenced a schema with a relative external reference. Which was silently failing before in the browser's console, but was fixed with this change.