### PR TITLE
Pmk65 datetime

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,7 @@ module.exports = function(grunt) {
           'src/editors/upload.js',
           'src/editors/checkbox.js',
           'src/editors/array/selectize.js',
+          'src/editors/datetime.js', 
 
           // All the themes and iconlibs
           'src/theme.js',

--- a/docs/datetime.html
+++ b/docs/datetime.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>JSON Editor datetime Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flatpickr/4.5.1/flatpickr.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flatpickr/4.5.1/flatpickr.min.css">
+  </head>
+  <body>
+    <h1>JSON Editor datetime Example</h1>
+    
+    <p style='margin-bottom:20px;'>This example demonstrates JSONEditor's datetime format and integration with Flatpickr</p>
+    
+    <div id='editor_holder'></div>
+    <button id='submit'>Submit (console.log)</button>
+    
+    <script>
+
+      // Initialize the editor with a JSON schema
+      var editor = new JSONEditor(document.getElementById('editor_holder'),{
+        schema: {
+          type: "object",
+          title: "Text",
+          required: ["sdate","stime","sdatetime","fsdate","fstime","fsdatetime"],
+          properties: {
+            "sdate": {
+              "type": "string",
+              "format": "date",
+              "title": "Date (String)",
+              "description": "String date field",
+              "required": true,
+              "options": {
+                "required": true,
+                "grid_columns": 4,
+                "placeholder": "Enter date"
+              }
+            },
+            "stime": {
+              "type": "string",
+              "format": "time",
+              "title": "Time (String)",
+              "description": "String time field",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter time",
+                "required": true
+              }
+            },
+            "sdatetime": {
+              "type": "string",
+              "format": "datetime-local",
+              "title": "Datetime (String)",
+              "description": "String datetime-local field",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter datetime",
+                "required": true
+              }
+            },
+
+            "fsdate": {
+              "type": "string",
+              "format": "date",
+              "title": "Date (String)",
+              "description": "String date field with flatpickr",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter date",
+                "flatpickr": {
+                  "inlineHideInput": true,
+                  "wrap": true,
+                  "allowInput": true
+                }
+              }
+            },
+            "fstime": {
+              "type": "string",
+              "format": "time",
+              "title": "Time (String)",
+              "description": "String time field with flatpickr",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter time",
+                "flatpickr": {
+                  "wrap": true,
+                  "showClearButton": false,
+                  "inlineHideInput": true,
+                  "defaultHour": 7,
+                  "defaultMinute": 19,
+                  "enableSeconds": true,
+                  "hourIncrement": 2,
+                  "minuteIncrement": 3,
+                  "time_24hr": true,
+                  "allowInput": true
+                }
+              }
+            },
+            "fsdatetime": {
+              "type": "string",
+              "format": "datetime-local",
+              "title": "Datetime (String)",
+              "description": "String datetime-local field with flatpickr",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter datetime",
+                "flatpickr": {
+                  "wrap": true,
+                  "time_24hr": true,
+                  "allowInput": true
+                }
+              }
+            },
+
+            "idate": {
+              "type": "integer",
+              "format": "date",
+              "title": "Date (Integer)",
+              "description": "Integer date field",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter date"
+              }
+            },
+            "itime": {
+              "type": "integer",
+              "format": "time",
+              "title": "Time (Integer)",
+              "description": "Integer time field",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter time"
+              }
+            },
+            "idatetime": {
+              "type": "integer",
+              "format": "datetime-local",
+              "title": "Datetime (Integer)",
+              "description": "Integer datetime-local field",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter datetime"
+              }
+            },
+
+            "fidate": {
+              "type": "integer",
+              "format": "date",
+              "title": "Date (Integer)",
+              "description": "Integer date field with flatpickr",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter date"
+              }
+            },
+            "fitime": {
+              "type": "integer",
+              "format": "time",
+              "title": "Time (Integer)",
+              "description": "Integer time field with flatpickr",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter time"
+              }
+            },
+            "fidatetime": {
+              "type": "integer",
+              "format": "datetime-local",
+              "title": "Datetime (Integer)",
+              "description": "Integer datetime-local field with flatpickr",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter datetime"
+              }
+            },
+
+            "fisdatetime": {
+              "type": "string",
+              "format": "datetime-local",
+              "title": "Datetime (String)",
+              "description": "Standard datetime-local field with inline flatpickr",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter datetime",
+                "flatpickr": {
+                  "inline": true,
+                  "time_24hr": true,
+                  "allowInput": true
+                }
+              }
+            },
+            "fisdate": {
+              "type": "string",
+              "format": "date",
+              "title": "Date (String)",
+              "description": "Standard date field with inline flatpickr and hidden input",
+              "options": {
+                "grid_columns": 4,
+                "placeholder": "Enter datetime",
+                "flatpickr": {
+                  "inlineHideInput": false,
+                  "inline": true,
+                  "time_24hr": true,
+                  "allowInput": true
+                }
+              }
+            }
+          }
+        }
+      });
+
+      // Hook up the submit button to log to the console
+      document.getElementById('submit').addEventListener('click',function() {
+        // Get the value from the editor
+        console.log(editor.getValue());
+      });
+    </script>
+  </body>
+</html>

--- a/docs/datetime.html
+++ b/docs/datetime.html
@@ -1,220 +1,286 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML>
+
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <title>JSON Editor datetime Example</title>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flatpickr/4.5.1/flatpickr.min.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flatpickr/4.5.1/flatpickr.min.css">
-  </head>
-  <body>
-    <h1>JSON Editor datetime Example</h1>
-    
-    <p style='margin-bottom:20px;'>This example demonstrates JSONEditor's datetime format and integration with Flatpickr</p>
-    
-    <div id='editor_holder'></div>
-    <button id='submit'>Submit (console.log)</button>
-    
-    <script>
 
-      // Initialize the editor with a JSON schema
-      var editor = new JSONEditor(document.getElementById('editor_holder'),{
-        schema: {
-          type: "object",
-          title: "Text",
-          required: ["sdate","stime","sdatetime","fsdate","fstime","fsdatetime"],
-          properties: {
-            "sdate": {
-              "type": "string",
-              "format": "date",
-              "title": "Date (String)",
-              "description": "String date field",
-              "required": true,
-              "options": {
-                "required": true,
-                "grid_columns": 4,
-                "placeholder": "Enter date"
-              }
-            },
-            "stime": {
-              "type": "string",
-              "format": "time",
-              "title": "Time (String)",
-              "description": "String time field",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter time",
-                "required": true
-              }
-            },
-            "sdatetime": {
-              "type": "string",
-              "format": "datetime-local",
-              "title": "Datetime (String)",
-              "description": "String datetime-local field",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter datetime",
-                "required": true
-              }
-            },
+<head>
+  <title>datetime editor examples</title>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
-            "fsdate": {
-              "type": "string",
-              "format": "date",
-              "title": "Date (String)",
-              "description": "String date field with flatpickr",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter date",
-                "flatpickr": {
-                  "inlineHideInput": true,
-                  "wrap": true,
-                  "allowInput": true
-                }
-              }
-            },
-            "fstime": {
-              "type": "string",
-              "format": "time",
-              "title": "Time (String)",
-              "description": "String time field with flatpickr",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter time",
-                "flatpickr": {
-                  "wrap": true,
-                  "showClearButton": false,
-                  "inlineHideInput": true,
-                  "defaultHour": 7,
-                  "defaultMinute": 19,
-                  "enableSeconds": true,
-                  "hourIncrement": 2,
-                  "minuteIncrement": 3,
-                  "time_24hr": true,
-                  "allowInput": true
-                }
-              }
-            },
-            "fsdatetime": {
-              "type": "string",
-              "format": "datetime-local",
-              "title": "Datetime (String)",
-              "description": "String datetime-local field with flatpickr",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter datetime",
-                "flatpickr": {
-                  "wrap": true,
-                  "time_24hr": true,
-                  "allowInput": true
-                }
-              }
-            },
+  <!-- Enable responsive viewport -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-            "idate": {
-              "type": "integer",
-              "format": "date",
-              "title": "Date (Integer)",
-              "description": "Integer date field",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter date"
-              }
-            },
-            "itime": {
-              "type": "integer",
-              "format": "time",
-              "title": "Time (Integer)",
-              "description": "Integer time field",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter time"
-              }
-            },
-            "idatetime": {
-              "type": "integer",
-              "format": "datetime-local",
-              "title": "Datetime (Integer)",
-              "description": "Integer datetime-local field",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter datetime"
-              }
-            },
+  <!-- jQuery -->
+  <script type="text/javascript" src="../cv/lib/jquery/dist/jquery.min.js"></script>
 
-            "fidate": {
-              "type": "integer",
-              "format": "date",
-              "title": "Date (Integer)",
-              "description": "Integer date field with flatpickr",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter date"
-              }
-            },
-            "fitime": {
-              "type": "integer",
-              "format": "time",
-              "title": "Time (Integer)",
-              "description": "Integer time field with flatpickr",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter time"
-              }
-            },
-            "fidatetime": {
-              "type": "integer",
-              "format": "datetime-local",
-              "title": "Datetime (Integer)",
-              "description": "Integer datetime-local field with flatpickr",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter datetime"
-              }
-            },
+  <!-- Bootstrap2
+  <link href="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+  <script type="text/javascript" src="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
+  -->
 
-            "fisdatetime": {
-              "type": "string",
-              "format": "datetime-local",
-              "title": "Datetime (String)",
-              "description": "Standard datetime-local field with inline flatpickr",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter datetime",
-                "flatpickr": {
-                  "inline": true,
-                  "time_24hr": true,
-                  "allowInput": true
-                }
-              }
-            },
-            "fisdate": {
-              "type": "string",
-              "format": "date",
-              "title": "Date (String)",
-              "description": "Standard date field with inline flatpickr and hidden input",
-              "options": {
-                "grid_columns": 4,
-                "placeholder": "Enter datetime",
-                "flatpickr": {
-                  "inlineHideInput": false,
-                  "inline": true,
-                  "time_24hr": true,
-                  "allowInput": true
-                }
-              }
+  <!-- Bootstrap3 -->
+ <link href="../cv/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="../cv/lib/bootstrap/dist/css/bootstrap-theme.min.css" rel="stylesheet">
+  <script type="text/javascript" src="../cv/lib/bootstrap/dist/js/bootstrap.min.js"></script>
+
+  <!-- Foundation
+  <script type="text/javascript" src=""></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.2.4/foundation.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" />
+  -->
+
+  <!-- Handlebars -->
+  <script type="text/javascript" src="../cv/lib/handlebars/handlebars.min.js"></script>
+
+  <!-- Flatpickr -->
+  <script type="text/javascript" src="node_modules/flatpickr/dist/flatpickr.min.js"></script>
+
+  <!-- JSON-Editor -->
+  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+
+  <style type="text/css">
+  body {
+    margin: 1em;
+  }
+
+  </style>
+</head>
+
+<body>
+  <h2>Extended handling of date, time and datetime-local type fields.</h2>
+
+  <p>Works with both string and integer data types. (If integer is used, the date will be returned in epoch format)</p>
+  <p>Adds support for setting "placeholder" through options.</p>
+  <p>Has optional support for using <a href="https://flatpickr.js.org/" target="_blank" title="Flatpickr datepicker">flatpickr datepicker</a>.</p>
+  <p>All flatpickr options is supported with a few minor differences.
+  <ul>
+    <li>"<strong>enableTime</strong>" and "<strong>noCalendar</strong>" are set automatically, based on the data type.</li>
+    <li>Extra config option "<strong>errorDateFormat</strong>". If this is set, it will replace the format displayed in error messages.</li>
+    <li>It is not possible to use "<strong>inline</strong>" and "<strong>wrap</strong>" options together.</li>
+    <li>When using the "<strong>wrap</strong>" option, "toggle" and "clear" buttons are automatically added to markup. 2 extra boolean options ("<strong>showToggleButton</strong>" and "<strong>showClearButton</strong>") are available to control which buttons to display. Note: not all frameworks supports this. (Works in: Bootstrap and Foundation)</li>
+    <li>When using the "inline" option, an extra boolean option ("<strong>inlineHideInput</strong>") is available to hide the original input field.</li>
+    <li>If "mode" is set to either "multiple" or "range", only string data type is supported. Also the result from these is returned as a string, not an array.</li>
+  </ul></p>
+  <div id="form"></div>
+  <script type="text/javascript">
+
+  // Handlebars helper for displaying timestamps in human frindly format
+  Handlebars.registerHelper("TimeStampToDateTime", function(ts) {
+    return ts ? new Date(ts * 1000) : 'empty';
+  });
+
+  var options = {
+    "theme": "bootstrap3",
+    "template": "handlebars",
+    "iconlib": "bootstrap3",
+    "schema": {
+      "title": "datetime editor examples",
+      "id": "test",
+      "type": "object",
+      "format": "grid",
+      "options": {
+        "disable_edit_json": false,
+        "disable_properties": false
+      },
+      "properties": {
+        "sdate": {
+          "type": "string",
+          "format": "date",
+          "title": "Date (String)",
+          "description": "Standard date field",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter date"
+          }
+        },
+        "stime": {
+          "type": "string",
+          "format": "time",
+          "title": "Time (String)",
+          "description": "Standard time field",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter time"
+          }
+        },
+        "sdatetime": {
+          "type": "string",
+          "format": "datetime-local",
+          "title": "Datetime (String)",
+          "description": "Standard datetime-local field",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "YYYY-MM-DD HH:SS"
+          }
+        },
+
+        "fsdate": {
+          "type": "string",
+          "format": "date",
+          "title": "Date (String)",
+          "description": "Standard date field with flatpickr",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter date",
+            "flatpickr": {
+              "inlineHideInput": true,
+              "wrap": true,
+              "allowInput": true
             }
           }
-        }
-      });
+        },
+        "fstime": {
+          "type": "string",
+          "format": "time",
+          "title": "Time (String)",
+          "description": "Standard time field with flatpickr",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter time",
+            "flatpickr": {
+              "wrap": true,
+              "showClearButton": false,
+              "inlineHideInput": true,
+              "defaultHour": 7,
+              "defaultMinute": 19,
+              "enableSeconds": true,
+              "hourIncrement": 2,
+              "minuteIncrement": 3,
+              "time_24hr": true,
+              "allowInput": true
+            }
+          }
+        },
+        "fsdatetime": {
+          "type": "string",
+          "format": "datetime-local",
+          "title": "Datetime (String)",
+          "description": "Standard datetime-local field with flatpickr",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter datetime",
+            "flatpickr": {
+              "wrap": true,
+              "time_24hr": true,
+              "allowInput": true
+            }
+          }
+        },
 
-      // Hook up the submit button to log to the console
-      document.getElementById('submit').addEventListener('click',function() {
-        // Get the value from the editor
-        console.log(editor.getValue());
-      });
-    </script>
-  </body>
+        "idate": {
+          "type": "integer",
+          "format": "date",
+          "title": "Date (Integer)",
+          "description": "Integer date field",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter date"
+          }
+        },
+        "itime": {
+          "type": "integer",
+          "format": "time",
+          "title": "Time (Integer)",
+          "description": "Integer time field",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter time"
+          }
+        },
+        "idatetime": {
+          "type": "integer",
+          "format": "datetime-local",
+          "title": "Datetime (Integer)",
+          "description": "Integer datetime-local field",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter datetime"
+          }
+        },
+
+        "fidate": {
+          "type": "integer",
+          "format": "date",
+          "title": "Date (Integer)",
+          "description": "Integer date field with flatpickr",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter date",
+            "flatpickr": {
+              "wrap": true,
+              "time_24hr": true,
+              "allowInput": true
+            }
+          }
+        },
+        "fitime": {
+          "type": "integer",
+          "format": "time",
+          "title": "Time (Integer)",
+          "description": "Integer time field with flatpickr",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter time",
+            "flatpickr": {
+              "wrap": true,
+              "time_24hr": true,
+              "allowInput": true
+            }
+          }
+        },
+        "fidatetime": {
+          "type": "integer",
+          "format": "datetime-local",
+          "title": "Datetime (Integer)",
+          "description": "Integer datetime-local field with flatpickr",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter datetime",
+            "flatpickr": {
+              "wrap": true,
+              "time_24hr": true,
+              "allowInput": true
+            }
+          }
+        },
+
+        "fisdatetime": {
+          "type": "string",
+          "format": "datetime-local",
+          "title": "Datetime (String)",
+          "description": "Standard datetime-local field with inline flatpickr",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter datetime",
+            "flatpickr": {
+              "inline": true,
+              "time_24hr": true
+            }
+          }
+        },
+        "fisdate": {
+          "type": "string",
+          "format": "date",
+          "title": "Date (String)",
+          "description": "Standard date field with inline flatpickr and hidden input",
+          "options": {
+            "grid_columns": 4,
+            "placeholder": "Enter datetime",
+            "flatpickr": {
+              "inlineHideInput": true,
+              "inline": true,
+              "time_24hr": true
+            }
+          }
+        },
+
+      }
+    }
+  }
+
+  var element = document.getElementById('form');
+  var editor = new JSONEditor(element, options);
+
+  </script>
+</body>
+
 </html>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -342,7 +342,7 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
 });
 // Specialized editor for date, time and datetime-local formats
 JSONEditor.defaults.resolvers.unshift(function(schema) {
-  if (['string', 'integer'].indexOf(schema.type) != -1 && ['date', 'time', 'datetime-local'].indexOf(schema.format) != -1) {
+  if (['string', 'integer'].indexOf(schema.type) !== -1 && ['date', 'time', 'datetime-local'].indexOf(schema.format) !== -1) {
     return "datetime";
   }
 });

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -172,6 +172,11 @@ JSONEditor.defaults.languages.en = {
    */
   error_datetime_local: 'Datetime must be in the format {{0}}',
   /**
+   * When a integer date is less than 1 January 1970
+   */
+  error_invalid_epoch: 'Date must be greater than 1 January 1970',
+
+  /**
    * Text on Delete All buttons
    */
   button_delete_all: "All",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -218,7 +218,15 @@ JSONEditor.defaults.languages.en = {
   /**
     * Title on Expand buttons
     */
-  button_expand: "Expand"
+  button_expand: "Expand",
+  /**
+    * Title on Flatpickr toggle buttons
+    */
+  flatpickr_toggle_button: "Toggle",
+  /**
+    * Title on Flatpickr clear buttons
+    */
+  flatpickr_clear_button: "Clear"
 };
 
 // Miscellaneous Plugin Settings

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -157,6 +157,21 @@ JSONEditor.defaults.languages.en = {
    */
   error_dependency: "Must have property {{0}}",
   /**
+   * When a date is in incorrect format
+   * @variables This key takes one variable: The valid format
+   */
+  error_date: 'Date must be in the format {{0}}',
+  /**
+   * When a time is in incorrect format
+   * @variables This key takes one variable: The valid format
+   */
+  error_time: 'Time must be in the format {{0}}',
+  /**
+   * When a datetime-local is in incorrect format
+   * @variables This key takes one variable: The valid format
+   */
+  error_datetime_local: 'Datetime must be in the format {{0}}',
+  /**
    * Text on Delete All buttons
    */
   button_delete_all: "All",
@@ -316,4 +331,11 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
 JSONEditor.defaults.resolvers.unshift(function(schema) {
   // If this schema uses `oneOf` or `anyOf`
   if(schema.oneOf || schema.anyOf) return "multiple";
+});
+
+// Specialized editor for date, time and datetime-local formats
+JSONEditor.defaults.resolvers.unshift(function(schema) {
+  if (['string', 'integer'].indexOf(schema.type) != -1 && ['date', 'time', 'datetime-local'].indexOf(schema.format) != -1) {
+    return "datetime";
+  }
 });

--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -1,0 +1,181 @@
+JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend({
+  build: function () {
+    this._super();
+    if(!this.input) return;
+
+    // Add placeholder text if available
+    if (this.options.placeholder) this.input.setAttribute('placeholder', this.options.placeholder);
+
+    // helper functions
+    this.zeroPad = function(value) {
+      return ('0' + value).slice(-2);
+    };
+
+    if(window.flatpickr && typeof this.options.flatpickr == 'object') {
+
+      // Make sure that flatpickr settings matches the input type
+      this.options.flatpickr.enableTime = this.schema.format == 'date' ? false : true;
+      this.options.flatpickr.noCalendar = this.schema.format == 'time' ? true : false;
+
+      // only string can contain range or multiple values
+      if (this.schema.type == 'integer') this.options.flatpickr.mode = 'single';
+
+      var input = this.input;
+
+      if (this.options.flatpickr.wrap === true) {
+
+        // Make sure "inline" option is turned off
+        this.options.flatpickr.inline = false;
+
+        // Create input-group container
+        var buttonContainer = document.createElement('div');
+        buttonContainer.className = 'input-group';
+
+        // Insert container after input field
+        this.input.parentNode.insertBefore(buttonContainer, this.input.nextSibling);
+
+        // Move input into container
+        buttonContainer.appendChild(this.input);
+
+        // Attribute for flatpicker
+        this.input.setAttribute('data-input','');
+
+        // Create button group and button
+        var buttonGroup = document.createElement('div');
+        buttonGroup.className = 'input-group-btn';
+        var button = this.getButton('',this.schema.format == 'time' ? 'time' :'calendar', this.translate('flatpickr_button'));
+
+        // Attribute for flatpicker
+        button.setAttribute('data-toggle','');
+
+        buttonGroup.appendChild(button);
+        buttonContainer.appendChild(buttonGroup);
+
+        input = buttonContainer;
+      }
+
+      this.flatpickr = window.flatpickr(input, this.options.flatpickr);
+
+      if (this.options.flatpickr.inline === true && this.options.flatpickr.inlineHideInput === true) {
+          this.input.setAttribute('type','hidden');
+      }
+    }
+  },
+  getValue: function() {
+    if (!this.dependenciesFulfilled) {
+      return undefined;
+    }
+    if (this.schema.type == 'string') {
+      return this.value;
+    }
+    if (this.value === '' || this.value === undefined) {
+      return undefined;
+    }
+
+    var value =  this.schema.format == 'time' ? '1970-01-01 ' + this.value : this.value;
+    return parseInt(new Date(value).getTime() / 1000);
+  },
+  setValue: function(value, initial, from_template) {
+    if (this.schema.type == 'string') {
+      this._super();
+    }
+    else {
+      var dateValue, dateObj = new Date(value * 1000),
+          year = dateObj.getFullYear(),
+          month = this.zeroPad(dateObj.getMonth() + 1),
+          day = this.zeroPad(dateObj.getDate()),
+          hour = this.zeroPad(dateObj.getHours()),
+          min = this.zeroPad(dateObj.getMinutes()),
+          sec = this.zeroPad(dateObj.getSeconds()),
+          date = [year, month, day].join('-'),
+          time = [hour, min, sec].join(':');
+
+      if (this.schema.format == 'date') dateValue = date;
+      else if (this.schema.format == 'time') dateValue = time;
+      else dateValue = date + ' ' + time;
+
+      this.value = dateValue;
+    }
+  },
+  destroy: function() {
+    if (this.flatpickr) this.flatpickr.destroy();
+    this.flatpickr = null;
+    this._super();
+  }
+});
+
+JSONEditor.defaults.custom_validators.push(function(schema, value, path) {
+  var errors = [];
+
+  if(['date', 'time', 'datetime-local'].indexOf(schema.format) != -1) {
+
+    var validator = {
+        'date': /^(\d{4}\D\d{2}\D\d{2})?$/,
+        'time': /^(\d{2}:\d{2}(?::\d{2})?)?$/,
+        'datetime-local': /^(\d{4}\D\d{2}\D\d{2} \d{2}:\d{2}(?::\d{2})?)?$/
+    };
+    var format = {
+        'date': '"YYYY-MM-DD"',
+        'time': '"HH:MM"',
+        'datetime-local': '"YYYY-MM-DD HH:MM"'
+    };
+
+    var ed = this.jsoneditor.getEditor(path);
+
+    if (schema.type == 'integer') {
+      // The value is a timestamp
+      // not much to check for, so we assume value is ok if it's a positive number
+      if (value != Math.abs(parseInt(value))) {
+        var dateFormat = ed.flatpickr ? ed.flatpickr.config.dateFormat : format[ed.format];
+        errors.push({
+          path: path,
+          property: 'format',
+          message: this.translate('error_' + ed.format.replace(/-/g, "_"), [dateFormat])
+        });
+      }
+    }
+    else if (!ed.flatpickr) {
+      // Standard string input, without flatpickr
+      if(!validator[ed.format].test(value)) {
+        errors.push({
+          path: path,
+          property: 'format',
+          message: this.translate('error_' + ed.format.replace(/-/g, "_"), [format[ed.format]])
+        });
+      }
+    }
+    else {
+      // Flatpickr validation
+      if (value !== '') {
+
+        var compareValue;
+        if(ed.flatpickr.config.mode != 'single') {
+          var seperator = ed.flatpickr.config.mode == 'range' ? ed.flatpickr.l10n.rangeSeparator : ', ';
+          var selectedDates = ed.flatpickr.selectedDates.map(function(val) {
+              return ed.flatpickr.formatDate(val, ed.flatpickr.config.dateFormat);
+          });
+          compareValue = selectedDates.join(seperator);
+        }
+
+        try {
+          if (compareValue) {
+            // Not the best validation method, but range and multiple mode are special
+            // Optimal solution would be if it is possible to change the field format from string/integer to array
+            // in these 2 special cases.
+            if (compareValue != value) throw ed.flatpickr.config.mode + ' mismatch';
+          }
+          else if (ed.flatpickr.formatDate(ed.flatpickr.parseDate(value, ed.flatpickr.config.dateFormat), ed.flatpickr.config.dateFormat) != value) throw 'mismatch';
+        }
+        catch(err) {
+          errors.push({
+            path: path,
+            property: 'format',
+            message: this.translate('error_' + ed.format.replace(/-/g, "_"), [ed.flatpickr.config.dateFormat])
+          });
+        }
+      }
+    }
+  }
+
+  return errors;
+});

--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -28,11 +28,11 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
     this._super();
     if(!this.input) return;
 
-    // Add placeholder text if available
+    // Add required and placeholder text if available
     if (this.options.placeholder !== undefined) this.input.setAttribute('placeholder', this.options.placeholder);
     if (this.options.required !== undefined) this.input.setAttribute('required', this.options.required);
 
-    // helper functions
+    // helper function
     this.zeroPad = function(value) {
       return ('0' + value).slice(-2);
     };
@@ -43,7 +43,7 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
       this.options.flatpickr.enableTime = this.schema.format == 'date' ? false : true;
       this.options.flatpickr.noCalendar = this.schema.format == 'time' ? true : false;
 
-      // only string can contain range or multiple values
+      // Curently only string can contain range or multiple values
       if (this.schema.type == 'integer') this.options.flatpickr.mode = 'single';
 
       var input = this.input;

--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -7,20 +7,26 @@ Adds support for setting "placeholder" through options.
 Has optional support for using flatpickr datepicker.
 All flatpickr options is supported with a few minor differences.
 - "enableTime" and "noCalendar" are set automatically, based on the data type.
+- Extra config option "errorDateFormat". If this is set, it will replace the format displayed in error messages.
 - It is not possible to use "inline" and "wrap" options together.
 - When using the "wrap" option, "toggle" and "clear" buttons are automatically added to markup. 2 extra boolean options ("showToggleButton" and "showClearButton") are available to control which buttons to display. Note: not all frameworks supports this. (Plain HTML and jQueryUI doesn't)
 - When using the "inline" option, an extra boolean option ("inlineHideInput") is available to hide the original input field.
 - If "mode" is set to either "multiple" or "range", only string data type is supported. Also the result from these is returned as a string not an array.
 
 ToDo:
- - Improve Handling of flatpicker "multiple" and "range" modes. (Currently the values are just added as string values, but the optimal scenario would be to save those as array if possible)
-- Supress the "Value must be of type integer." error message when using "integer" type. As this doesn't make sense, since the input is string. (Probably will need to hack into the default "integer" validation and skip if schema format is "datetime")
-- Test if validation works with "required" fields. (Not sure if I have to put this into custom validator, or if it's handled elsewhere. Update: required is not supported at all!)
-- Convert flatpickr date tokens into human readable format (HRF). (ie. "Y-m-d H:i" to "YYYY-MM-DD HH:MM") But Im not sure if this is possible, as date tokens also support textual values. And how do you display those in HRF??
+- Supress the "Value must be of type integer." error message when using "integer" type. As this doesn't make sense, since the input is string. (Probably will need to hack into the default "integer" validation and skip if schema format is "datetime") - DONE
+
+- Convert flatpickr date tokens into human readable format (HRF). (ie. "Y-m-d H:i" to "YYYY-MM-DD HH:MM") But Im not sure if this is possible, as date tokens also support textual values. And how do you display those in HRF?? - DONE - Added an extra config options (errorDateFormat) instead .
+
 - Add support for "required" attribute. (Maybe this should be done on a general scale, as support for other input attributes are also missing, such as "placeholder")
 - Test with different frameworks, as the "input-group-btn" is probably Bootstrap specific.
   Foundation 6: https://foundation.zurb.com/sites/docs/forms.html#inline-labels-and-buttons
   Materialize: (Icon Prefixes) https://materializecss.com/text-inputs.html
+  Working: foundation,bootstrap3
+
+- Test if validation works with "required" fields. (Not sure if I have to put this into custom validator, or if it's handled elsewhere. UPDATE required is not supported at all!)
+
+ - Improve Handling of flatpicker "multiple" and "range" modes. (Currently the values are just added as string values, but the optimal scenario would be to save those as array if possible)
 
 */
 JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend({
@@ -46,6 +52,9 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
       // Curently only string can contain range or multiple values
       if (this.schema.type == 'integer') this.options.flatpickr.mode = 'single';
 
+      // Attribute for flatpicker
+      this.input.setAttribute('data-input','');
+
       var input = this.input;
 
       if (this.options.flatpickr.wrap === true) {
@@ -53,38 +62,35 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
         // Make sure "inline" option is turned off
         this.options.flatpickr.inline = false;
 
-        // Create input-group container
-        var buttonContainer = document.createElement('div');
-        buttonContainer.className = 'input-group';
-
-        // Insert container after input field
-        this.input.parentNode.insertBefore(buttonContainer, this.input.nextSibling);
-
-        // Move input into container
-        buttonContainer.appendChild(this.input);
-
-        // Attribute for flatpicker
-        this.input.setAttribute('data-input','');
-
-        // Create button group and button
-        var buttonGroup = document.createElement('div');
-        buttonGroup.className = 'input-group-btn'; // Bootstrap specific, so need to test with other frameworks
-
+        // Create buttons for input group
+        var buttons = [];
         if (this.options.flatpickr.showToggleButton !== false) {
           var toggleButton = this.getButton('',this.schema.format == 'time' ? 'time' :'calendar', this.translate('flatpickr_toggle_button'));
           // Attribute for flatpicker
           toggleButton.setAttribute('data-toggle','');
-          buttonGroup.appendChild(toggleButton);
+          buttons.push(toggleButton);
         }
         if (this.options.flatpickr.showClearButton !== false) {
           var clearButton = this.getButton('','delete', this.translate('flatpickr_clear_button'));
           // Attribute for flatpicker
           clearButton.setAttribute('data-clear','');
-          buttonGroup.appendChild(clearButton);
+          buttons.push(clearButton);
         }
 
-        buttonContainer.appendChild(buttonGroup);
-        input = buttonContainer;
+        // Save position of input field
+        var parentNode = this.input.parentNode, nextSibling = this.input.nextSibling;
+
+        var buttonContainer = this.theme.getInputGroup(this.input, buttons);
+        if (buttonContainer !== undefined) {
+          // Insert container at same position as input field
+          parentNode.insertBefore(buttonContainer, nextSibling);
+
+          input = buttonContainer;
+        }
+        else {
+          this.options.flatpickr.wrap = false;
+        }
+
       }
 
       this.flatpickr = window.flatpickr(input, this.options.flatpickr);
@@ -200,10 +206,11 @@ JSONEditor.defaults.custom_validators.push(function(schema, value, path) {
           else if (ed.flatpickr.formatDate(ed.flatpickr.parseDate(value, ed.flatpickr.config.dateFormat), ed.flatpickr.config.dateFormat) != value) throw 'mismatch';
         }
         catch(err) {
+          var errorDateFormat = ed.flatpickr.config.errorDateFormat !== undefined ? ed.flatpickr.config.errorDateFormat : ed.flatpickr.config.dateFormat;
           errors.push({
             path: path,
             property: 'format',
-            message: this.translate('error_' + ed.format.replace(/-/g, "_"), [ed.flatpickr.config.dateFormat])
+            message: this.translate('error_' + ed.format.replace(/-/g, "_"), [errorDateFormat])
           });
         }
       }

--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -14,20 +14,11 @@ All flatpickr options is supported with a few minor differences.
 - If "mode" is set to either "multiple" or "range", only string data type is supported. Also the result from these is returned as a string not an array.
 
 ToDo:
-- Supress the "Value must be of type integer." error message when using "integer" type. As this doesn't make sense, since the input is string. (Probably will need to hack into the default "integer" validation and skip if schema format is "datetime") - DONE
-
-- Convert flatpickr date tokens into human readable format (HRF). (ie. "Y-m-d H:i" to "YYYY-MM-DD HH:MM") But Im not sure if this is possible, as date tokens also support textual values. And how do you display those in HRF?? - DONE - Added an extra config options (errorDateFormat) instead .
-
 - Add support for "required" attribute. (Maybe this should be done on a general scale, as support for other input attributes are also missing, such as "placeholder")
-- Test with different frameworks, as the "input-group-btn" is probably Bootstrap specific. DONE
 
-- Test if validation works with "required" fields. (Not sure if I have to put this into custom validator, or if it's handled elsewhere. UPDATE required is not supported at all!)
+- Test if validation works with "required" fields. (Not sure if I have to put this into custom validator, or if it's handled elsewhere. UPDATE required attribute is currently not supported at ALL!)
 
  - Improve Handling of flatpicker "multiple" and "range" modes. (Currently the values are just added as string values, but the optimal scenario would be to save those as array if possible)
-
-- Set limit on integer input
-min: = 00:00:00 UTC Thursday, 1 January 1970
-max =  3:14:08 on 19 January 2038 UTC
 
 */
 JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend({
@@ -37,12 +28,7 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
 
     // Add required and placeholder text if available
     if (this.options.placeholder !== undefined) this.input.setAttribute('placeholder', this.options.placeholder);
-    if (this.options.required !== undefined) this.input.setAttribute('required', this.options.required);
-
-    // helper function
-    this.zeroPad = function(value) {
-      return ('0' + value).slice(-2);
-    };
+    //if (this.options.required !== undefined) this.input.setAttribute('required', this.options.required);
 
     if(window.flatpickr && typeof this.options.flatpickr == 'object') {
 
@@ -60,9 +46,6 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
 
       if (this.options.flatpickr.wrap === true) {
 
-        // Make sure "inline" option is turned off
-        this.options.flatpickr.inline = false;
-
         // Create buttons for input group
         var buttons = [];
         if (this.options.flatpickr.showToggleButton !== false) {
@@ -72,7 +55,7 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
           buttons.push(toggleButton);
         }
         if (this.options.flatpickr.showClearButton !== false) {
-          var clearButton = this.getButton('','delete', this.translate('flatpickr_clear_button'));
+          var clearButton = this.getButton('','clear', this.translate('flatpickr_clear_button'));
           // Attribute for flatpicker
           clearButton.setAttribute('data-clear','');
           buttons.push(clearButton);
@@ -83,6 +66,9 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
 
         var buttonContainer = this.theme.getInputGroup(this.input, buttons);
         if (buttonContainer !== undefined) {
+          // Make sure "inline" option is turned off
+          this.options.flatpickr.inline = false;
+
           // Insert container at same position as input field
           parentNode.insertBefore(buttonContainer, nextSibling);
 
@@ -141,6 +127,10 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
     if (this.flatpickr) this.flatpickr.destroy();
     this.flatpickr = null;
     this._super();
+  },
+  // helper function
+  zeroPad: function(value) {
+    return ('0' + value).slice(-2);
   }
 });
 

--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -1,10 +1,36 @@
+/*
+
+Edtended handling of date, time and datetime-local type fields.
+
+Works with both string and integer data types. (default only support string type)
+Adds support for setting "placeholder" through options.
+Has optional support for using flatpickr datepicker.
+All flatpickr options is supported with a few minor differences.
+- "enableTime" and "noCalendar" are set automatically, based on the data type.
+- It is not possible to use "inline" and "wrap" options together.
+- When using the "wrap" option, "toggle" and "clear" buttons are automatically added to markup. 2 extra boolean options ("showToggleButton" and "showClearButton") are available to control which buttons to display. Note: not all frameworks supports this. (Plain HTML and jQueryUI doesn't)
+- When using the "inline" option, an extra boolean option ("inlineHideInput") is available to hide the original input field.
+- If "mode" is set to either "multiple" or "range", only string data type is supported. Also the result from these is returned as a string not an array.
+
+ToDo:
+ - Improve Handling of flatpicker "multiple" and "range" modes. (Currently the values are just added as string values, but the optimal scenario would be to save those as array if possible)
+- Supress the "Value must be of type integer." error message when using "integer" type. As this doesn't make sense, since the input is string. (Probably will need to hack into the default "integer" validation and skip if schema format is "datetime")
+- Test if validation works with "required" fields. (Not sure if I have to put this into custom validator, or if it's handled elsewhere. Update: required is not supported at all!)
+- Convert flatpickr date tokens into human readable format (HRF). (ie. "Y-m-d H:i" to "YYYY-MM-DD HH:MM") But Im not sure if this is possible, as date tokens also support textual values. And how do you display those in HRF??
+- Add support for "required" attribute. (Maybe this should be done on a general scale, as support for other input attributes are also missing, such as "placeholder")
+- Test with different frameworks, as the "input-group-btn" is probably Bootstrap specific.
+  Foundation 6: https://foundation.zurb.com/sites/docs/forms.html#inline-labels-and-buttons
+  Materialize: (Icon Prefixes) https://materializecss.com/text-inputs.html
+
+*/
 JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend({
   build: function () {
     this._super();
     if(!this.input) return;
 
     // Add placeholder text if available
-    if (this.options.placeholder) this.input.setAttribute('placeholder', this.options.placeholder);
+    if (this.options.placeholder !== undefined) this.input.setAttribute('placeholder', this.options.placeholder);
+    if (this.options.required !== undefined) this.input.setAttribute('required', this.options.required);
 
     // helper functions
     this.zeroPad = function(value) {
@@ -42,7 +68,7 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
 
         // Create button group and button
         var buttonGroup = document.createElement('div');
-        buttonGroup.className = 'input-group-btn';
+        buttonGroup.className = 'input-group-btn'; // Bootstrap specific, so need to test with other frameworks
 
         if (this.options.flatpickr.showToggleButton !== false) {
           var toggleButton = this.getButton('',this.schema.format == 'time' ? 'time' :'calendar', this.translate('flatpickr_toggle_button'));

--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -28,7 +28,6 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
 
     // Add required and placeholder text if available
     if (this.options.placeholder !== undefined) this.input.setAttribute('placeholder', this.options.placeholder);
-    //if (this.options.required !== undefined) this.input.setAttribute('required', this.options.required);
 
     if(window.flatpickr && typeof this.options.flatpickr == 'object') {
 
@@ -198,8 +197,7 @@ JSONEditor.defaults.custom_validators.push(function(schema, value, path) {
         try {
           if (compareValue) {
             // Not the best validation method, but range and multiple mode are special
-            // Optimal solution would be if it is possible to change the field format from string/integer to array
-            // in these 2 special cases.
+            // Optimal solution would be if it is possible to change the return format from string/integer to array
             if (compareValue != value) throw ed.flatpickr.config.mode + ' mismatch';
           }
           else if (ed.flatpickr.formatDate(ed.flatpickr.parseDate(value, ed.flatpickr.config.dateFormat), ed.flatpickr.config.dateFormat) != value) throw 'mismatch';

--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -43,14 +43,21 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
         // Create button group and button
         var buttonGroup = document.createElement('div');
         buttonGroup.className = 'input-group-btn';
-        var button = this.getButton('',this.schema.format == 'time' ? 'time' :'calendar', this.translate('flatpickr_button'));
 
-        // Attribute for flatpicker
-        button.setAttribute('data-toggle','');
+        if (this.options.flatpickr.showToggleButton !== false) {
+          var toggleButton = this.getButton('',this.schema.format == 'time' ? 'time' :'calendar', this.translate('flatpickr_toggle_button'));
+          // Attribute for flatpicker
+          toggleButton.setAttribute('data-toggle','');
+          buttonGroup.appendChild(toggleButton);
+        }
+        if (this.options.flatpickr.showClearButton !== false) {
+          var clearButton = this.getButton('','delete', this.translate('flatpickr_clear_button'));
+          // Attribute for flatpicker
+          clearButton.setAttribute('data-clear','');
+          buttonGroup.appendChild(clearButton);
+        }
 
-        buttonGroup.appendChild(button);
         buttonContainer.appendChild(buttonGroup);
-
         input = buttonContainer;
       }
 

--- a/src/iconlibs/bootstrap2.js
+++ b/src/iconlibs/bootstrap2.js
@@ -9,6 +9,7 @@ JSONEditor.defaults.iconlibs.bootstrap2 = JSONEditor.AbstractIconLib.extend({
     save: 'ok',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
+    clear: 'remove-circle',
     time: 'time',
     calendar: 'calendar'
   },

--- a/src/iconlibs/bootstrap2.js
+++ b/src/iconlibs/bootstrap2.js
@@ -8,7 +8,9 @@ JSONEditor.defaults.iconlibs.bootstrap2 = JSONEditor.AbstractIconLib.extend({
     cancel: 'ban-circle',
     save: 'ok',
     moveup: 'arrow-up',
-    movedown: 'arrow-down'
+    movedown: 'arrow-down',
+    time: 'time',
+    calendar: 'calendar'
   },
   icon_prefix: 'icon-'
 });

--- a/src/iconlibs/bootstrap3.js
+++ b/src/iconlibs/bootstrap3.js
@@ -8,7 +8,9 @@ JSONEditor.defaults.iconlibs.bootstrap3 = JSONEditor.AbstractIconLib.extend({
     cancel: 'floppy-remove',
     save: 'floppy-saved',
     moveup: 'arrow-up',
-    movedown: 'arrow-down'
+    movedown: 'arrow-down',
+    time: 'time',
+    calendar: 'calendar'
   },
   icon_prefix: 'glyphicon glyphicon-'
 });

--- a/src/iconlibs/bootstrap3.js
+++ b/src/iconlibs/bootstrap3.js
@@ -9,6 +9,7 @@ JSONEditor.defaults.iconlibs.bootstrap3 = JSONEditor.AbstractIconLib.extend({
     save: 'floppy-saved',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
+    clear: 'remove-circle',
     time: 'time',
     calendar: 'calendar'
   },

--- a/src/iconlibs/fontawesome3.js
+++ b/src/iconlibs/fontawesome3.js
@@ -8,7 +8,9 @@ JSONEditor.defaults.iconlibs.fontawesome3 = JSONEditor.AbstractIconLib.extend({
     cancel: 'ban-circle',
     save: 'save',
     moveup: 'arrow-up',
-    movedown: 'arrow-down'
+    movedown: 'arrow-down',
+    time: 'time',
+    calendar: 'calendar'
   },
   icon_prefix: 'icon-'
 });

--- a/src/iconlibs/fontawesome3.js
+++ b/src/iconlibs/fontawesome3.js
@@ -9,6 +9,7 @@ JSONEditor.defaults.iconlibs.fontawesome3 = JSONEditor.AbstractIconLib.extend({
     save: 'save',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
+    clear: 'remove-circle',
     time: 'time',
     calendar: 'calendar'
   },

--- a/src/iconlibs/fontawesome4.js
+++ b/src/iconlibs/fontawesome4.js
@@ -9,7 +9,9 @@ JSONEditor.defaults.iconlibs.fontawesome4 = JSONEditor.AbstractIconLib.extend({
     save: 'save',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
-    copy: 'files-o'
+    copy: 'files-o',
+    time: 'clock-o',
+    calendar: 'calendar'
   },
   icon_prefix: 'fa fa-'
 });

--- a/src/iconlibs/fontawesome4.js
+++ b/src/iconlibs/fontawesome4.js
@@ -10,6 +10,7 @@ JSONEditor.defaults.iconlibs.fontawesome4 = JSONEditor.AbstractIconLib.extend({
     moveup: 'arrow-up',
     movedown: 'arrow-down',
     copy: 'files-o',
+    clear: 'times-circle-o',
     time: 'clock-o',
     calendar: 'calendar'
   },

--- a/src/iconlibs/foundation2.js
+++ b/src/iconlibs/foundation2.js
@@ -9,7 +9,7 @@ JSONEditor.defaults.iconlibs.foundation2 = JSONEditor.AbstractIconLib.extend({
     save: 'checkmark',
     moveup: 'up-arrow',
     movedown: 'down-arrow',
-    time: 'time',
+    time: 'clock',
     calendar: 'calendar'
   },
   icon_prefix: 'foundicon-'

--- a/src/iconlibs/foundation2.js
+++ b/src/iconlibs/foundation2.js
@@ -8,7 +8,9 @@ JSONEditor.defaults.iconlibs.foundation2 = JSONEditor.AbstractIconLib.extend({
     cancel: 'error',
     save: 'checkmark',
     moveup: 'up-arrow',
-    movedown: 'down-arrow'
+    movedown: 'down-arrow',
+    time: 'time',
+    calendar: 'calendar'
   },
   icon_prefix: 'foundicon-'
 });

--- a/src/iconlibs/foundation2.js
+++ b/src/iconlibs/foundation2.js
@@ -9,6 +9,7 @@ JSONEditor.defaults.iconlibs.foundation2 = JSONEditor.AbstractIconLib.extend({
     save: 'checkmark',
     moveup: 'up-arrow',
     movedown: 'down-arrow',
+    clear: 'remove',
     time: 'clock',
     calendar: 'calendar'
   },

--- a/src/iconlibs/foundation3.js
+++ b/src/iconlibs/foundation3.js
@@ -8,7 +8,9 @@ JSONEditor.defaults.iconlibs.foundation3 = JSONEditor.AbstractIconLib.extend({
     cancel: 'x-circle',
     save: 'save',
     moveup: 'arrow-up',
-    movedown: 'arrow-down'
+    movedown: 'arrow-down',
+    time: 'time',
+    calendar: 'calendar'
   },
   icon_prefix: 'fi-'
 });

--- a/src/iconlibs/foundation3.js
+++ b/src/iconlibs/foundation3.js
@@ -9,7 +9,7 @@ JSONEditor.defaults.iconlibs.foundation3 = JSONEditor.AbstractIconLib.extend({
     save: 'save',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
-    time: 'time',
+    time: 'clock',
     calendar: 'calendar'
   },
   icon_prefix: 'fi-'

--- a/src/iconlibs/foundation3.js
+++ b/src/iconlibs/foundation3.js
@@ -9,6 +9,7 @@ JSONEditor.defaults.iconlibs.foundation3 = JSONEditor.AbstractIconLib.extend({
     save: 'save',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
+    clear: 'x-circle',
     time: 'clock',
     calendar: 'calendar'
   },

--- a/src/iconlibs/jqueryui.js
+++ b/src/iconlibs/jqueryui.js
@@ -8,7 +8,9 @@ JSONEditor.defaults.iconlibs.jqueryui = JSONEditor.AbstractIconLib.extend({
     cancel: 'closethick',
     save: 'disk',
     moveup: 'arrowthick-1-n',
-    movedown: 'arrowthick-1-s'
+    movedown: 'arrowthick-1-s',
+    time: 'time',
+    calendar: 'calendar'
   },
   icon_prefix: 'ui-icon ui-icon-'
 });

--- a/src/iconlibs/jqueryui.js
+++ b/src/iconlibs/jqueryui.js
@@ -9,6 +9,7 @@ JSONEditor.defaults.iconlibs.jqueryui = JSONEditor.AbstractIconLib.extend({
     save: 'disk',
     moveup: 'arrowthick-1-n',
     movedown: 'arrowthick-1-s',
+    clear: 'circle-close',
     time: 'time',
     calendar: 'calendar'
   },

--- a/src/iconlibs/materialicons.js
+++ b/src/iconlibs/materialicons.js
@@ -11,6 +11,7 @@ JSONEditor.defaults.iconlibs.materialicons = JSONEditor.AbstractIconLib.extend({
       moveup: 'arrow_upward',
       movedown: 'arrow_downward',
       copy: 'content_copy',
+      clear: 'highlight_off',
       time: 'access_time',
       calendar: 'calendar_today'
     },

--- a/src/iconlibs/materialicons.js
+++ b/src/iconlibs/materialicons.js
@@ -1,16 +1,18 @@
 JSONEditor.defaults.iconlibs.materialicons = JSONEditor.AbstractIconLib.extend({
 
     mapping: {
-        collapse: 'arrow_drop_up',
-        expand: 'arrow_drop_down',
-        "delete": 'delete',
-        edit: 'edit',
-        add: 'add',
-        cancel: 'cancel',
-        save: 'save',
-        moveup: 'arrow_upward',
-        movedown: 'arrow_downward',
-        copy: 'content_copy'
+      collapse: 'arrow_drop_up',
+      expand: 'arrow_drop_down',
+      "delete": 'delete',
+      edit: 'edit',
+      add: 'add',
+      cancel: 'cancel',
+      save: 'save',
+      moveup: 'arrow_upward',
+      movedown: 'arrow_downward',
+      copy: 'content_copy',
+      time: 'access_time',
+      calendar: 'calendar_today'
     },
 
     icon_class: 'material-icons',

--- a/src/theme.js
+++ b/src/theme.js
@@ -432,5 +432,8 @@ JSONEditor.AbstractTheme = Class.extend({
   },
   getFirstTab: function(holder){
     return holder.firstChild.firstChild;
+  },
+  getInputGroup: function(input, buttons) {
+    return undefined;
   }
 });

--- a/src/themes/bootstrap2.js
+++ b/src/themes/bootstrap2.js
@@ -254,5 +254,22 @@ JSONEditor.defaults.themes.bootstrap2 = JSONEditor.AbstractTheme.extend({
 
     progressBar.className = 'progress progress-striped active';
     progressBar.firstChild.style.width = '100%';
+  },
+  getInputGroup: function(input, buttons) {
+    if (!input) return;
+
+    var inputGroupContainer = document.createElement('div');
+    inputGroupContainer.className = 'input-group';
+    inputGroupContainer.appendChild(input);
+
+    var inputGroup = document.createElement('div');
+    inputGroup.className = 'input-group-btn';
+    inputGroupContainer.appendChild(inputGroup);
+
+    for(var i=0;i<buttons.length;i++) {
+      inputGroup.appendChild(buttons[i]);
+    }
+
+    return inputGroupContainer;
   }
 });

--- a/src/themes/bootstrap2.js
+++ b/src/themes/bootstrap2.js
@@ -259,15 +259,12 @@ JSONEditor.defaults.themes.bootstrap2 = JSONEditor.AbstractTheme.extend({
     if (!input) return;
 
     var inputGroupContainer = document.createElement('div');
-    inputGroupContainer.className = 'input-group';
+    inputGroupContainer.className = 'input-append';
     inputGroupContainer.appendChild(input);
 
-    var inputGroup = document.createElement('div');
-    inputGroup.className = 'input-group-btn';
-    inputGroupContainer.appendChild(inputGroup);
-
     for(var i=0;i<buttons.length;i++) {
-      inputGroup.appendChild(buttons[i]);
+      buttons[i].classList.add('btn');
+      inputGroupContainer.appendChild(buttons[i]);
     }
 
     return inputGroupContainer;

--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -253,5 +253,22 @@ JSONEditor.defaults.themes.bootstrap3 = JSONEditor.AbstractTheme.extend({
     bar.removeAttribute('aria-valuenow');
     bar.style.width = '100%';
     bar.innerHTML = '';
+  },
+  getInputGroup: function(input, buttons) {
+    if (!input) return;
+
+    var inputGroupContainer = document.createElement('div');
+    inputGroupContainer.className = 'input-group';
+    inputGroupContainer.appendChild(input);
+
+    var inputGroup = document.createElement('div');
+    inputGroup.className = 'input-group-btn';
+    inputGroupContainer.appendChild(inputGroup);
+
+    for(var i=0;i<buttons.length;i++) {
+      inputGroup.appendChild(buttons[i]);
+    }
+
+    return inputGroupContainer;
   }
 });

--- a/src/themes/bootstrap4.js
+++ b/src/themes/bootstrap4.js
@@ -196,5 +196,22 @@ JSONEditor.defaults.themes.bootstrap4 = JSONEditor.AbstractTheme.extend({
     bar.removeAttribute("aria-valuenow");
     bar.style.width = "100%";
     bar.innerHTML = "";
+  },
+  getInputGroup: function(input, buttons) {
+    if (!input) return;
+
+    var inputGroupContainer = document.createElement('div');
+    inputGroupContainer.className = 'input-group';
+    inputGroupContainer.appendChild(input);
+
+    var inputGroup = document.createElement('div');
+    inputGroup.className = 'input-group-btn';
+    inputGroupContainer.appendChild(inputGroup);
+
+    for(var i=0;i<buttons.length;i++) {
+      inputGroup.appendChild(buttons[i]);
+    }
+
+    return inputGroupContainer;
   }
 });

--- a/src/themes/foundation.js
+++ b/src/themes/foundation.js
@@ -112,6 +112,25 @@ JSONEditor.defaults.themes.foundation = JSONEditor.AbstractTheme.extend({
   updateProgressBarUnknown: function(progressBar) {
     if (!progressBar) return;
     progressBar.firstChild.style.width = '100%';
+  },
+  getInputGroup: function(input, buttons) {
+    if (!input) return undefined;
+
+    var inputGroupContainer = document.createElement('div');
+    inputGroupContainer.className = 'input-group';
+    input.classList.add('input-group-field');
+    inputGroupContainer.appendChild(input);
+
+    for(var i=0;i<buttons.length;i++) {
+      var inputGroup = document.createElement('div');
+      inputGroup.className = 'input-group-button';
+      inputGroup.style.verticalAlign = 'top';
+      buttons[i].classList.remove('small');   
+      inputGroup.appendChild(buttons[i]);
+      inputGroupContainer.appendChild(inputGroup);
+    }
+
+    return inputGroupContainer;
   }
 });
 

--- a/src/validator.js
+++ b/src/validator.js
@@ -142,7 +142,18 @@ JSONEditor.Validator = Class.extend({
       }
       // Simple type
       else {
-        if(!this._checkType(schema.type, value)) {
+        if(['date', 'time', 'datetime-local'].indexOf(schema.format) != -1 && schema.type == 'integer') {
+          // Hack to get validator to validate as string even if value is integer
+          // As validation of 'date', 'time', 'datetime-local' is done in separate validator
+          if(!this._checkType('string', ""+value)) {
+            errors.push({
+              path: path,
+              property: 'type',
+              message: this.translate('error_type', [schema.format])
+            });
+          }
+        }
+        else if(!this._checkType(schema.type, value)) {
           errors.push({
             path: path,
             property: 'type',


### PR DESCRIPTION
**Extended handling of date, time and datetime-local type fields.**

Works with both string and integer data types. (If integer is used, the date will be returned in epoch format)
Adds support for setting "placeholder" through options.
Has optional support for using [flatpickr ](https://flatpickr.js.org/) datepicker.
Includes example HTML/JavaScript in the docs/ folder.

All [flatpickr ](https://flatpickr.js.org/) options is supported with a few minor differences.

- "enableTime" and "noCalendar" are set automatically, based on the data type.
- Extra config option "errorDateFormat". If this is set, it will replace the format displayed in error messages.
- It is not possible to use "inline" and "wrap" options together.
- When using the "wrap" option, "toggle" and "clear" buttons are automatically added to markup. 2 extra boolean options ("showToggleButton" and "showClearButton") are available to control which buttons to display. Note: not all frameworks supports this. (Works in: Bootstrap and Foundation)
- When using the "inline" option, an extra boolean option ("inlineHideInput") is available to hide the original input field.
- If "mode" is set to either "multiple" or "range", only string data type is supported. Also the result from these is returned as a string, not an array.
