### PR TITLE
[DO NOT MERGE] Example enumSource reorder fix, preserve value at Move Up or Down

### DIFF
--- a/docs/enumsource.html
+++ b/docs/enumsource.html
@@ -16,6 +16,11 @@
     where any changes to ordering of the enumSource array reset selections to a start value.
   </p>
 
+  <p style='margin-bottom:20px;'>
+    With <a href="https://github.com/json-editor/json-editor/pull/187">PR 187</a> please note
+    the suspicious behavior when a referenced item is deleted.
+  </p>
+
   <div id='editor_holder'></div>
   <button id='submit'>Submit (console.log)</button>
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@json-editor/json-editor",
+  "name": "@yolean/json-editor",
   "title": "JSONEditor",
   "description": "JSON Schema based editor",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.1",
   "main": "dist/jsoneditor.js",
   "author": {
     "name": "Jeremy Dorn",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@yolean/json-editor",
   "title": "JSONEditor",
   "description": "JSON Schema based editor",
-  "version": "1.1.1-beta.1",
+  "version": "1.1.1-beta.2",
   "main": "dist/jsoneditor.js",
   "author": {
     "name": "Jeremy Dorn",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prepare": "./node_modules/.bin/grunt",
     "build": "npm install && ./node_modules/.bin/grunt",
     "start": "./node_modules/.bin/grunt watch",
+    "serve": "./node_modules/.bin/grunt serve",
     "test": "./node_modules/.bin/grunt test",
     "serve-test": "./node_modules/.bin/grunt serve-test",
     "docker-test": "cd tests && docker-compose run --rm node npm run build && docker-compose up -d && docker-compose ps && docker-compose run --rm codeceptjs codeceptjs run --grep '(?=.*)^(?!.*@optional)'",

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "editor"
   ],
   "scripts": {
-    "prepare": "grunt",
-    "build": "npm install && grunt",
-    "start": "grunt watch",
-    "test": "grunt test",
-    "serve-test": "grunt serve-test",
+    "prepare": "./node_modules/.bin/grunt",
+    "build": "npm install && ./node_modules/.bin/grunt",
+    "start": "./node_modules/.bin/grunt watch",
+    "test": "./node_modules/.bin/grunt test",
+    "serve-test": "./node_modules/.bin/grunt serve-test",
     "docker-test": "cd tests && docker-compose run --rm node npm run build && docker-compose up -d && docker-compose ps && docker-compose run --rm codeceptjs codeceptjs run --grep '(?=.*)^(?!.*@optional)'",
     "preversion": "npm run docker-test",
-    "version": "grunt string-replace",
+    "version": "./node_modules/.bin/grunt string-replace",
     "postversion": "git push && git push --tags && npm publish ./ --access public"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@yolean/json-editor",
   "title": "JSONEditor",
   "description": "JSON Schema based editor",
-  "version": "1.1.1-beta.2",
+  "version": "1.2.0-beta.1",
   "main": "dist/jsoneditor.js",
   "author": {
     "name": "Jeremy Dorn",

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -331,7 +331,8 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
       }
 
       // If the previous value is still in the new select options, stick with it
-      if(select_options.indexOf(prev_value) !== -1) {
+      // We have not found a case where else is preferable since it breakes when you reorder the enum source
+      if(true) {
         this.input.value = prev_value;
         this.value = prev_value;
       }


### PR DESCRIPTION
Submitting this PR for reference, but not for merge as it might be a regression to many users of enumSource. Instead it is published as `@yolean/json-editor` until a solution is found that satisfies all use cases (is there such a list?).

The tradeoff we make in `select.js` is that no value is selected automatically upon deletion, but on the other hand values are kept at Move Up and Move Down. Historically they've been lost and the first value was selected.