### PR TITLE
Fix adding classes to DOMTokenList

### DIFF
--- a/src/iconlib.js
+++ b/src/iconlib.js
@@ -21,7 +21,8 @@ JSONEditor.AbstractIconLib = Class.extend({
     if(!iconclass) return null;
     
     var i = document.createElement('i');
-    i.classList.add(iconclass);
+    i.classList.add.apply(i.classList, iconclass.split(' '));
+    
     return i;
   }
 });


### PR DESCRIPTION
Fix for some iconlib options where adding multiple classes as a string separated by spaces breaks the native `DOMTokenList` add api eg. `'foo bar'`