### PR TITLE
Added editor function to create valid ID values and fixed array.js + …

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -541,6 +541,12 @@ JSONEditor.AbstractEditor = Class.extend({
     
     return disp;
   },
+
+  // Replace space(s) with "-" to create valid id value
+  getValidId: function(id) {
+    id = id === undefined ? "" : id.toString();
+    return id.replace(/\s+/g, "-");
+  },
   getOption: function(key) {
     try {
       throw "getOption is deprecated";

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -105,7 +105,7 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
       if(this.schema.format === 'tabs-top') {
         this.controls = this.theme.getHeaderButtonHolder();
         this.title.appendChild(this.controls);
-        this.tabs_holder = this.theme.getTopTabHolder(this.getItemTitle());
+        this.tabs_holder = this.theme.getTopTabHolder(this.getValidId(this.getItemTitle()));
         this.container.appendChild(this.tabs_holder);
         this.row_holder = this.theme.getTopTabContentHolder(this.tabs_holder);
 
@@ -114,7 +114,7 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
       else if(this.schema.format === 'tabs') {
         this.controls = this.theme.getHeaderButtonHolder();
         this.title.appendChild(this.controls);
-        this.tabs_holder = this.theme.getTabHolder(this.getItemTitle());
+        this.tabs_holder = this.theme.getTabHolder(this.getValidId(this.getItemTitle()));
         this.container.appendChild(this.tabs_holder);
         this.row_holder = this.theme.getTabContentHolder(this.tabs_holder);
 
@@ -483,11 +483,11 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
       self.rows[i].tab_text = document.createElement('span');
       self.rows[i].tab_text.textContent = self.rows[i].getHeaderText();
       if(self.schema.format === 'tabs-top'){
-        self.rows[i].tab = self.theme.getTopTab(self.rows[i].tab_text,self.rows[i].path);
+        self.rows[i].tab = self.theme.getTopTab(self.rows[i].tab_text,this.getValidId(self.rows[i].path));
         self.theme.addTopTab(self.tabs_holder, self.rows[i].tab);
       }
       else {
-        self.rows[i].tab = self.theme.getTab(self.rows[i].tab_text,self.rows[i].path);
+        self.rows[i].tab = self.theme.getTab(self.rows[i].tab_text,this.getValidId(self.rows[i].path));
         self.theme.addTab(self.tabs_holder, self.rows[i].tab);
       }
       self.rows[i].tab.addEventListener('click', function(e) {

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -184,7 +184,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
           }
         }
 
-        aPane.id = editor.tab_text.textContent;
+        aPane.id = self.getValidId(editor.tab_text.textContent);
 
         //For simple properties, add them on the same panel (Basic)
         if(!isObjOrArray){
@@ -393,7 +393,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
         } else {
           self.rows[idx].tab_text.textContent = self.rows[idx].getHeaderText();
         }
-        self.rows[idx].tab = self.theme.getTopTab(self.rows[idx].tab_text,self.rows[idx].tab_text.textContent);
+        self.rows[idx].tab = self.theme.getTopTab(self.rows[idx].tab_text,this.getValidId(self.rows[idx].tab_text.textContent));
         self.rows[idx].tab.addEventListener('click', function(e) {
           self.active_tab = self.rows[idx].tab;
           self.refreshTabs();
@@ -586,12 +586,12 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
       this.row_container = this.theme.getGridContainer();
 
       if(isCategoriesFormat) {
-        this.tabs_holder = this.theme.getTopTabHolder(this.schema.title);
+        this.tabs_holder = this.theme.getTopTabHolder(this.getValidId(this.schema.title));
         this.tabPanesContainer = this.theme.getTopTabContentHolder(this.tabs_holder);
         this.editor_holder.appendChild(this.tabs_holder);
       }
       else {
-        this.tabs_holder = this.theme.getTabHolder(this.schema.title);
+        this.tabs_holder = this.theme.getTabHolder(this.getValidId(this.schema.title));
         this.tabPanesContainer = this.theme.getTabContentHolder(this.tabs_holder);
         this.editor_holder.appendChild(this.row_container);
       }
@@ -626,7 +626,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
 
           self.addRow(editor,self.tabs_holder,aPane);
 
-          aPane.id = editor.schema.title; //editor.schema.path//tab_text.textContent
+          aPane.id = self.getValidId(editor.schema.title); //editor.schema.path//tab_text.textContent
 
         }
         else {

--- a/src/themes/bootstrap4.js
+++ b/src/themes/bootstrap4.js
@@ -122,7 +122,7 @@ JSONEditor.defaults.themes.bootstrap4 = JSONEditor.AbstractTheme.extend({
   getTopTabHolder: function(propertyName) {
     var pName = (typeof propertyName === 'undefined')? "" : propertyName;
     var el = document.createElement('div');
-    el.innerHTML = "<ul class='nav nav-tabs' id='" + pName + "'></ul><div class='card-body' id='" + pName + "'></div>";
+    el.innerHTML = "<ul class='nav nav-tabs' id='" + pName + "'></ul><div class='card-body tab-content' id='" + pName + "'></div>";
     return el;
   },
   getTab: function(text,tabId) {
@@ -132,6 +132,7 @@ JSONEditor.defaults.themes.bootstrap4 = JSONEditor.AbstractTheme.extend({
     ael.classList.add("nav-link");
     ael.setAttribute("style",'padding:10px;');
     ael.setAttribute("href", "#" + tabId);
+    ael.setAttribute('data-toggle', 'tab');
     ael.appendChild(text);
     liel.appendChild(ael);
     return liel;
@@ -142,19 +143,30 @@ JSONEditor.defaults.themes.bootstrap4 = JSONEditor.AbstractTheme.extend({
     var a = document.createElement('a');
     a.classList.add('nav-link');
     a.setAttribute('href','#'+tabId);
+    a.setAttribute('data-toggle', 'tab');
     a.appendChild(text);
     el.appendChild(a);
     return el;
   },
+  getTabContent: function() {
+    var el = document.createElement('div');
+    el.classList.add('tab-pane');
+    el.setAttribute('role', 'tabpanel');
+    return el;
+  },
+  getTopTabContent: function() {
+    var el = document.createElement('div');
+    el.classList.add('tab-pane');
+    el.setAttribute('role', 'tabpanel');
+    return el;
+  },
   markTabActive: function(row) {
-    var el = row.tab.firstChild;
-    el.classList.add("active");
-    row.container.style.display = '';
+    row.tab.classList.add('active');
+    row.container.classList.add('active');
   },
   markTabInactive: function(row) {
-    var el = row.tab.firstChild;
-    el.classList.remove('active');
-    row.container.style.display = 'none';
+    row.tab.classList.remove('active');
+    row.container.classList.remove('active');
   },
   getProgressBar: function() {
     var min = 0,

--- a/src/themes/foundation.js
+++ b/src/themes/foundation.js
@@ -442,7 +442,7 @@ JSONEditor.defaults.themes.foundation6 = JSONEditor.defaults.themes.foundation5.
   markTabInactive: function(row) {
     row.tab.classList.remove('is-active');
     row.tab.firstChild.removeAttribute('aria-selected');
-    row.container.classList.add('is-active');
+    row.container.classList.remove('is-active');
     row.container.removeAttribute('aria-selected');
   },
   addTab: function(holder, tab) {


### PR DESCRIPTION
The object.js and array.js editors both use the title to generate ID values. But if the title contains spaces it will generate invalid values. This fix replaces space(s) with a "-" dash.
(Haven't been able to fix the multiple uses of identical IDs)

Also fixed problem with Tabs (categories) not working in Bootstrap4 theme.