### PR TITLE
Improve performance of theme.setButtonText

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -257,10 +257,13 @@ JSONEditor.AbstractTheme = Class.extend({
     return el;
   },
   setButtonText: function(button, text, icon, title) {
-    button.innerHTML = '';
+    // Clear previous contents. https://jsperf.com/innerhtml-vs-removechild/37
+    while (button.firstChild) {
+      button.removeChild(button.firstChild);
+    }
     if(icon) {
       button.appendChild(icon);
-      button.innerHTML += ' ';
+      text = ' ' + text;
     }
     button.appendChild(document.createTextNode(text));
     if(title) button.setAttribute('title',title);


### PR DESCRIPTION
Profiling showed that for large object trees, a significant portion of time was being spent in setButtonText.
Removing the `innerHTML += ' '` fixes this.

I also use a better-performing strategy for removing the contents of the button, although that's probably a premature optimization.

This is one small change that can impact #252 . Unfortunately, in the grand scheme of things, this still makes a barely-noticeable difference in the time it takes to set values in the editor. I think other changes are likely to be far more meaningful.