### PR TITLE
Moved inputAttributes function to editor.js + support for number and select

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -547,6 +547,17 @@ JSONEditor.AbstractEditor = Class.extend({
     id = id === undefined ? "" : id.toString();
     return id.replace(/\s+/g, "-");
   },
+  setInputAttributes: function(protected) {
+    if (this.schema.options && this.schema.options.inputAttributes) {
+      var inputAttributes = this.schema.options.inputAttributes;
+      protected = ['name', 'type'].concat(protected);
+      for (var key in inputAttributes) {
+        if (inputAttributes.hasOwnProperty(key) && protected.indexOf(key.toLowerCase()) == -1) {
+          this.input.setAttribute(key, inputAttributes[key]);
+        }
+      }
+    }
+  },
   getOption: function(key) {
     try {
       throw "getOption is deprecated";

--- a/src/editors/number.js
+++ b/src/editors/number.js
@@ -27,6 +27,9 @@ JSONEditor.defaults.editors.number = JSONEditor.defaults.editors.string.extend({
       this.input.setAttribute("step", step);
     }
 
+    // Set custom attributes on input element. Parameter is array of protected keys. Empty array if none.
+    this.setInputAttributes(['maxlength', 'pattern', 'readonly', 'min', 'max', 'step']);
+
   },
   sanitize: function(value) {
     return (value+"").replace(/[^0-9\.\-eE]/g,'');

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -179,6 +179,9 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
       this.input.disabled = true;
     }
 
+    // Set custom attributes on input element. Parameter is array of protected keys. Empty array if none.
+    this.setInputAttributes([]);
+
     this.input.addEventListener('change',function(e) {
       e.preventDefault();
       e.stopPropagation();

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -190,14 +190,8 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
       this.input.setAttribute('readonly', 'true');
     }
 
-    if (this.schema.options && this.schema.options.inputAttributes) {
-      var inputAttributes = this.schema.options.inputAttributes;
-      for (var key in inputAttributes) {
-        if (inputAttributes.hasOwnProperty(key)) {
-          this.input.setAttribute(key, inputAttributes[key]);
-        }
-      }
-    }
+    // Set custom attributes on input element. Parameter is array of protected keys. Empty array if none.
+    this.setInputAttributes(['maxlength', 'pattern', 'readonly', 'min', 'max', 'step']);
 
     this.input
       .addEventListener('change',function(e) {        


### PR DESCRIPTION
I created a global "setInputAttributes" function in editor.js as it's pretty much the same code used in all editors except for the protected keys (which is a parameter for the new function)

Also added the functionality to select and number/integer types.

