### PR TITLE
Adds support for Cleave.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following are not required, but can improve the style and usability of JSON 
 *  [Selectize](https://selectize.github.io/selectize.js/) for nicer Select & Array boxes
 *  [Flatpickr](https://flatpickr.js.org/) lightweight and powerful datetime picker
 *  [Signature Pad](https://github.com/szimek/signature_pad) HTML5 canvas based smooth signature drawing
+*  [Cleave.js](https://github.com/nosir/cleave.js) Format your **&lt;input/&gt;** content when you are typing
 *  [math.js](http://mathjs.org/) for more accurate floating point math (multipleOf, divisibleBy, etc.)
 
 Usage
@@ -55,6 +56,7 @@ If you learn best by example, check these out:
 *  Advanced Usage Example - http://rawgithub.com/json-editor/json-editor/master/docs/advanced.html
 *  CSS Integration Example - http://rawgithub.com/json-editor/json-editor/master/docs/css_integration.html
 *  Base64 Editor Example (Muiltple Upload) - http://rawgithub.com/json-editor/json-editor/master/docs/multiple_upload_base64.html
+*  Cleave.js Editor Example - http://rawgithub.com/json-editor/json-editor/master/docs/cleave.html  
 *  Datetime Editor Example - http://rawgithub.com/json-editor/json-editor/master/docs/datetime.html
 *  Recursive JSON Editor Example - http://rawgithub.com/json-editor/json-editor/master/docs/recursive.html
 *  Select2 Editor Example - http://rawgithub.com/json-editor/json-editor/master/docs/select2.html
@@ -618,8 +620,11 @@ Here is an example that will show a color picker in browsers that support it:
 }
 ```
 
-### String Editors Input Attributes
-You can set custom attributes such as placeholder, classname and data- on the input field using the special options keyword `inputAttributes`. Like this:
+#### String Editors Input Attributes
+
+You can set custom attributes such as **placeholder**, **class** and **data-** on the input field using the special options keyword `inputAttributes`.
+
+Like this:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following are not required, but can improve the style and usability of JSON 
 *  [Selectize](https://selectize.github.io/selectize.js/) for nicer Select & Array boxes
 *  [Flatpickr](https://flatpickr.js.org/) lightweight and powerful datetime picker
 *  [Signature Pad](https://github.com/szimek/signature_pad) HTML5 canvas based smooth signature drawing
-*  [Cleave.js](https://github.com/nosir/cleave.js) Format your **&lt;input/&gt;** content when you are typing
+*  [Cleave.js](https://github.com/nosir/cleave.js) for formatting your **&lt;input/&gt;** content while you are typing
 *  [math.js](http://mathjs.org/) for more accurate floating point math (multipleOf, divisibleBy, etc.)
 
 Usage
@@ -56,7 +56,7 @@ If you learn best by example, check these out:
 *  Advanced Usage Example - http://rawgithub.com/json-editor/json-editor/master/docs/advanced.html
 *  CSS Integration Example - http://rawgithub.com/json-editor/json-editor/master/docs/css_integration.html
 *  Base64 Editor Example (Muiltple Upload) - http://rawgithub.com/json-editor/json-editor/master/docs/multiple_upload_base64.html
-*  Cleave.js Editor Example - http://rawgithub.com/json-editor/json-editor/master/docs/cleave.html  
+*  Cleave.js Editor Example - http://rawgithub.com/json-editor/json-editor/master/docs/cleave.html
 *  Datetime Editor Example - http://rawgithub.com/json-editor/json-editor/master/docs/datetime.html
 *  Recursive JSON Editor Example - http://rawgithub.com/json-editor/json-editor/master/docs/recursive.html
 *  Select2 Editor Example - http://rawgithub.com/json-editor/json-editor/master/docs/select2.html

--- a/docs/cleave.html
+++ b/docs/cleave.html
@@ -1,0 +1,142 @@
+<!DOCTYPE HTML>
+
+<html>
+
+<head>
+  <title>Cleave.js editor examples</title>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+
+  <!-- Enable responsive viewport -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- jQuery -->
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+
+  <!-- Bootstrap3 -->
+  <!-- Latest compiled and minified CSS -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <!-- Optional theme -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" >
+  <!-- Latest compiled and minified JavaScript -->
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" ></script>
+
+  <!-- Foundation
+  <script type="text/javascript" src=""></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.2.4/foundation.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" />
+  -->
+
+  <!-- Cleave.js -->
+    <script src="https://cdn.jsdelivr.net/npm/cleave.js@1.4.7/dist/cleave.min.js" integrity="sha256-/vtm6dO6rn9i2XRWyrQX8uvtO0qHrkYiEuI5hNvFHHk=" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/cleave.js@1.4.7/dist/addons/cleave-phone.dk.js"></script>
+  <!-- JSON-Editor
+  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+               -->
+               <script type="text/javascript" src="../dist/jsoneditor.min.js"></script>
+
+  <style type="text/css">
+  body {
+    margin: 1em;
+  }
+
+  </style>
+</head>
+
+<body>
+  <h2>Example showing how to use Cleave.js to format your &lt;input/&gt; content when you are typing.</h2>
+
+  <p>For documentation on the Cleave.js options, look at <a href="https://github.com/nosir/cleave.js" target="_blank" title="Cleave.js Github">Cleave.js</a> Github page. You can also find a lot of examples in this <a href="https://jsfiddle.net/nosir/aLnhdf3z/" target="_blank" title="Cleave.js JSFiddle">JSFiddle</a> page.</p>
+  <div id="form"></div>
+  <script type="text/javascript">
+
+  // Show the creditcard type in the field 'help-block' section
+  // Possible values: uatp, amex, diners, discover, mastercard, dankort, instapayment, jcb15, jcb, maestro, visa, mir, unionPay, general, generalStrict, unknown
+  var creditCardTypeChangedHandler = function(type) {
+    var el = this.element.nextSibling;
+    if (el && el.classList.contains('help-block')) {
+      el.innerHTML = 'Card type: <strong>' + type + '</strong>';
+    }
+  }
+
+  var options = {
+    "theme": "bootstrap3",
+    "template": "handlebars",
+    "iconlib": "bootstrap3",
+    "schema": {
+      "title": "Cleave.js editor examples",
+      "id": "test",
+      "type": "object",
+      "format": "grid",
+      "options": {
+        "disable_edit_json": false,
+        "disable_properties": false
+      },
+      "properties": {
+        "creditcard": {
+          "type": "string",
+          "title": "Credit Card",
+          "description": " ",
+          "options": {
+            "grid_columns": 6,
+            "inputAttributes": {
+              "placeholder": "enter credit card number"
+            },
+            "cleave": {
+              "creditCard": true,
+              "onCreditCardTypeChanged": creditCardTypeChangedHandler
+            }
+          }
+        },
+        "phone": {
+          "type": "string",
+          "title": "Phone number",
+          "description": "Phone number formatting (danish) + prefix",
+          "options": {
+            "grid_columns": 6,
+            "cleave": {
+              "phone": true,
+              "phoneRegionCode": "dk",
+              "prefix": "+45 ",
+              "noImmediatePrefix": false
+            }
+          }
+        },
+        "prefix": {
+          "type": "string",
+          "title": "Prefix",
+          "description": "Prefix",
+          "options": {
+            "grid_columns": 6,
+            "cleave": {
+              "prefix": "JE-"
+            }
+          }
+        },
+        "blocks": {
+          "type": "string",
+          "title": "Serial number",
+          "description": "Blocks, uppercase formatting",
+          "options": {
+            "grid_columns": 6,
+            "inputAttributes": {
+              "placeholder": "Enter serial number",
+            },
+            "cleave": {
+              "blocks": [3, 5, 5],
+              "uppercase": true,
+              "delimiter": "-",
+              "delimiterLazyShow": true
+            }
+          }
+        }
+      }
+    }
+  }
+
+  var element = document.getElementById('form');
+  var editor = new JSONEditor(element, options);
+
+  </script>
+</body>
+
+</html>

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -298,6 +298,13 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
       this.refreshValue();
     }
   },
+  postBuild: function() {
+    this._super();
+    // Enable cleave.js support if library is loaded and config is available
+    if (window.Cleave && this.schema.options && typeof this.schema.options.cleave == 'object') {
+      var cleave = new window.Cleave(this.input, this.schema.options.cleave);
+    }
+  },
   enable: function() {
     if(!this.always_disabled) {
       this.input.disabled = false;


### PR DESCRIPTION
Adds simple support for [cleave.js](https://nosir.github.io/cleave.js/) a library that Format your &lt;input/&gt; content when you are typing. See #247 

Works only with string types.