### PR TITLE
Updated CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Install package
 
 Using a CDN
 
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
 
-For local usage download the [production version](https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js) or the [development version](https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.js)
+You can also access older releases from CDN, using the landing page: https://www.jsdelivr.com/package/npm/@json-editor/json-editor
+
+For local usage download the [production version](https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js) or the [development version](https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.js)
 
 Requirements
 -----------------

--- a/docs/advanced.html
+++ b/docs/advanced.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Advanced JSON Editor Example</title>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
   </head>
   <body>
     <h1>Advanced JSON Editor Example</h1>

--- a/docs/basic.html
+++ b/docs/basic.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Basic JSON Editor Example</title>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
   </head>
   <body>
     <h1>Basic JSON Editor Example</h1>

--- a/docs/cleave.html
+++ b/docs/cleave.html
@@ -30,7 +30,7 @@
     <script src="https://cdn.jsdelivr.net/npm/cleave.js@1.4.7/dist/cleave.min.js" integrity="sha256-/vtm6dO6rn9i2XRWyrQX8uvtO0qHrkYiEuI5hNvFHHk=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/cleave.js@1.4.7/dist/addons/cleave-phone.dk.js"></script>
   <!-- JSON-Editor -->
-  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
 
   <style type="text/css">
   body {

--- a/docs/css_integration.html
+++ b/docs/css_integration.html
@@ -9,7 +9,7 @@
     <!-- Font Awesome icons (Bootstrap, Foundation, and jQueryUI also supported) -->
     <link rel='stylesheet' href='//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.0.3/css/font-awesome.css'>
 
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
     
     <script>
     // Set the default CSS theme and icon library globally

--- a/docs/datetime.html
+++ b/docs/datetime.html
@@ -34,7 +34,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flatpickr/4.5.1/flatpickr.min.css" />
 
   <!-- JSON-Editor -->
-  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
 
   <style type="text/css">
   body {

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -13,7 +13,7 @@
     <style>[class*="foundicon-"] {font-family: GeneralFoundicons;font-style: normal;}</style>
 
     <!-- JSON Editor -->
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
 
     <!-- LZString compression library - Used to create direct links to the demo - NOT REQUIRED for JSON Editor -->
     <script src="https://cdn.jsdelivr.net/npm/lz-string@1.4.4/libs/lz-string.min.js"></script>

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -118,6 +118,7 @@
                         <option value='flatpickr'>Flatpickr</option>
                         <option value='signature_pad'>Signature Pad</option>
                         <option value='mathjs'>Math.js</option>
+                        <option value='cleavejs'>Cleave.js</option>
                     </select>
                 </div>
             </div>
@@ -493,6 +494,7 @@ editor.on("change",  function() {
 
         var scriptMapping = {
           ace_editor: "https://cdn.jsdelivr.net/npm/ace-editor-builds@1.2.4/src-min-noconflict/ace.js",
+          cleavejs: "https://cdn.jsdelivr.net/npm/cleave.js@1.4.7/dist/cleave.min.js",
           sceditor: [
             "https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js",
             "https://cdn.jsdelivr.net/npm/sceditor@2.1.3/minified/sceditor.min.js",

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
     <link rel='stylesheet' id='icon_stylesheet'>
     <style>[class*="foundicon-"] {font-family: GeneralFoundicons;font-style: normal;}</style>
 
-  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
 
     <script>
         /**

--- a/docs/materialize_css.html
+++ b/docs/materialize_css.html
@@ -12,7 +12,7 @@
     </style>
 
     <!-- Scripts. -->
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
     <script>
         // Set the default CSS theme and icon library globally
         JSONEditor.defaults.theme = 'materialize';

--- a/docs/multiple_upload_base64.html
+++ b/docs/multiple_upload_base64.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>JSON Editor multiple file upload (base64)</title>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
   </head>
   <body>
     <h1>JSON Editor multiple file upload (base64)</h1>

--- a/docs/recursive.html
+++ b/docs/recursive.html
@@ -15,7 +15,7 @@
     <script src='//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.min.js'></script>
     <script src='//cdn.jsdelivr.net/sceditor/1.4.3/plugins/xhtml.js'></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
 </head>
 <body>
 <div class='container'>

--- a/docs/select2.html
+++ b/docs/select2.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>JSON Editor Select2 Integration Example</title>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
     <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="//cdn.jsdelivr.net/select2/3.4.8/select2.min.js"></script>
     <link rel="stylesheet" href="//cdn.jsdelivr.net/select2/3.4.8/select2.css">

--- a/docs/selectize.html
+++ b/docs/selectize.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>JSON Editor Selectize Integration Example</title>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js"></script>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/css/selectize.bootstrap3.css">

--- a/docs/signature.html
+++ b/docs/signature.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>JSON Editor signature drawing</title>
     <script src="https://cdn.jsdelivr.net/npm/signature_pad@2.3.2/dist/signature_pad.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
   </head>
   <body>
     <h1>JSON Editor: signature editor</h1>

--- a/docs/starrating.html
+++ b/docs/starrating.html
@@ -27,7 +27,7 @@
   -->
 
   <!-- JSON-Editor -->
-  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
 
   <style type="text/css">
   body {

--- a/docs/upload.html
+++ b/docs/upload.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>JSON Editor Upload Example</title>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
   </head>
   <body>
     <h1>JSON Editor Upload Example</h1>

--- a/docs/wysiwyg.html
+++ b/docs/wysiwyg.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>JSON Editor WYSIWYG Example</title>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
     <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.bbcode.min.js"></script>
     <link rel="stylesheet" href="//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.default.min.css">


### PR DESCRIPTION
Changed all occurrences of: 
https://cdn.jsdelivr.net/npm/@json-editor/json-editor/dist/
In docs/ and readme.me to:
https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/

Fixes the CDN problem outlined in #179 