### PR TITLE
Material Icons | Adding missed uploads icon

### DIFF
--- a/src/iconlibs/materialicons.js
+++ b/src/iconlibs/materialicons.js
@@ -13,7 +13,8 @@ JSONEditor.defaults.iconlibs.materialicons = JSONEditor.AbstractIconLib.extend({
       copy: 'content_copy',
       clear: 'highlight_off',
       time: 'access_time',
-      calendar: 'calendar_today'
+      calendar: 'calendar_today',
+      upload: 'cloud_upload',
     },
 
     icon_class: 'material-icons',


### PR DESCRIPTION
`upload` icon was missing, thus exception was thrown at [materialize.js#L47](https://github.com/json-editor/json-editor/blob/e695bddebe80cae79cb622d41d89b50d9814ccef/src/themes/materialize.js#L47)

```js
if (text) {
    icon.classList.add('left');
    icon.style.marginRight = '5px';
}
```

as `icon` war for `upload` was undefined.