### PR TITLE
Accept schema.options.ace as Ace Editor options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,21 @@ You can override the default Ace theme by setting the `JSONEditor.plugins.ace.th
 JSONEditor.plugins.ace.theme = 'twilight';
 ```
 
+You can enable [Ace editor options](https://github.com/ajaxorg/ace/wiki/Configuring-Ace) individually by setting the `options.ace` in schema.
+
+```json
+{
+  "type": "string",
+  "format": "sql",
+  "options": {
+    "ace": {
+      "enableBasicAutocompletion": true,
+      "enableLiveAutocompletion": true
+    }
+  }
+}
+```
+
 #### Booleans
 
 The default boolean editor is a select box with options "true" and "false".  To use a checkbox instead, set the format to `checkbox`.

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -375,6 +375,11 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
         this.input.style.display = 'none';
         this.ace_editor = window.ace.edit(this.ace_container);
         
+        var aceOptions = this.schema.options && this.schema.options.ace;
+        if (aceOptions) {
+          this.ace_editor.setOptions(aceOptions);
+        }
+
         this.ace_editor.setValue(this.getValue());
 
         // The theme


### PR DESCRIPTION
Accept `schema.options.ace` as Ace Editor options per its instance.

Enable auto completion extension for example.

```json
"query": {
	"type": "string",
	"format": "sql",
	"options": {
		"ace": {
			"enableBasicAutocompletion": true,
			"enableLiveAutocompletion": true,
			"enableSnippets": true						
		}
	}
}
```