### PR TITLE
Support underscore 1.7 and newer

### DIFF
--- a/src/templates/underscore.js
+++ b/src/templates/underscore.js
@@ -4,7 +4,7 @@ JSONEditor.defaults.templates.underscore = function() {
   return {
     compile: function(template) {
       return function(context) {
-        return window._.template(template, context);
+        return window._.template(template)(context);
       };
     }
   };


### PR DESCRIPTION
The underscore library made a breaking change with version 1.7.  `_.template()` now returns a function.

https://underscorejs.org/#template