### PR TITLE
removed hardcoded styling from 'oneOf' switcher

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -148,17 +148,9 @@ JSONEditor.AbstractTheme = Class.extend({
     return select;
   },
   getSwitcher: function(options) {
-    var switcher = this.getSelectInput(options);
-    switcher.style.backgroundColor = 'transparent';
-    switcher.style.display = 'inline-block';
-    switcher.style.fontStyle = 'italic';
-    switcher.style.fontWeight = 'normal';
-    switcher.style.height = 'auto';
-    switcher.style.marginBottom = 0;
-    switcher.style.marginLeft = '5px';
-    switcher.style.padding = '0 0 0 3px';
-    switcher.style.width = 'auto';
-    return switcher;
+    var s = this.getSelectInput(options);
+    s.className = (s.className || '') + ' switcher'
+    return s   
   },
   getSwitcherOptions: function(switcher) {
     return switcher.getElementsByTagName('option');

--- a/src/theme.js
+++ b/src/theme.js
@@ -149,8 +149,8 @@ JSONEditor.AbstractTheme = Class.extend({
   },
   getSwitcher: function(options) {
     var s = this.getSelectInput(options);
-    s.className = (s.className || '') + ' switcher'
-    return s   
+    s.className = (s.className || '') + ' switcher';
+    return s;
   },
   getSwitcherOptions: function(switcher) {
     return switcher.getElementsByTagName('option');


### PR DESCRIPTION
Removed hardcoded styling for the 'oneOf'-property (which i love to create conditional dynamic forms).
Not sure if this is the right timing, because it might effect the other styles.
On the other hand, it seems that not many people use 'oneOf' because i noticed a mixture of cleaned-up vs hardcoded ui-elements.