### PR TITLE
DOMPurify support for description text #329

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following are not required, but can improve the style and usability of JSON 
 *  [Signature Pad](https://github.com/szimek/signature_pad) HTML5 canvas based smooth signature drawing
 *  [Cleave.js](https://github.com/nosir/cleave.js) for formatting your **&lt;input/&gt;** content while you are typing
 *  [math.js](http://mathjs.org/) for more accurate floating point math (multipleOf, divisibleBy, etc.)
+*  [DOMPurify](https://github.com/cure53/DOMPurify) DOM-only, super-fast, uber-tolerant XSS sanitizer. (If you want to use HTML format in descriptions.)
 
 Usage
 --------------

--- a/src/theme.js
+++ b/src/theme.js
@@ -235,7 +235,7 @@ JSONEditor.AbstractTheme = Class.extend({
   },
   getDescription: function(text) {
     var el = document.createElement('p');
-    if (window.DOMPurify) el.innerHTML = text;
+    if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
     else el.textContent = text;
     return el;
   },

--- a/src/theme.js
+++ b/src/theme.js
@@ -235,7 +235,8 @@ JSONEditor.AbstractTheme = Class.extend({
   },
   getDescription: function(text) {
     var el = document.createElement('p');
-    el.innerHTML = text;
+    if (window.DOMPurify) el.innerHTML = text;
+    else el.textContent = text;
     return el;
   },
   getCheckboxDescription: function(text) {

--- a/src/themes/bootstrap2.js
+++ b/src/themes/bootstrap2.js
@@ -89,7 +89,7 @@ JSONEditor.defaults.themes.bootstrap2 = JSONEditor.AbstractTheme.extend({
   getFormInputDescription: function(text) {
     var el = document.createElement('p');
     el.classList.add('help-inline');
-    if (window.DOMPurify) el.innerHTML = text;
+    if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
     else el.textContent = text;
     return el;
   },

--- a/src/themes/bootstrap2.js
+++ b/src/themes/bootstrap2.js
@@ -89,7 +89,8 @@ JSONEditor.defaults.themes.bootstrap2 = JSONEditor.AbstractTheme.extend({
   getFormInputDescription: function(text) {
     var el = document.createElement('p');
     el.classList.add('help-inline');
-    el.textContent = text;
+    if (window.DOMPurify) el.innerHTML = text;
+    else el.textContent = text;
     return el;
   },
   getFormControl: function(label, input, description, infoText) {

--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -105,7 +105,8 @@ JSONEditor.defaults.themes.bootstrap3 = JSONEditor.AbstractTheme.extend({
   getFormInputDescription: function(text) {
     var el = document.createElement('p');
     el.classList.add('help-block');
-    el.innerHTML = text;
+    if (window.DOMPurify) el.innerHTML = text;
+    else el.textContent = text;
     return el;
   },
   getHeaderButtonHolder: function() {

--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -105,7 +105,7 @@ JSONEditor.defaults.themes.bootstrap3 = JSONEditor.AbstractTheme.extend({
   getFormInputDescription: function(text) {
     var el = document.createElement('p');
     el.classList.add('help-block');
-    if (window.DOMPurify) el.innerHTML = text;
+    if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
     else el.textContent = text;
     return el;
   },

--- a/src/themes/bootstrap4.js
+++ b/src/themes/bootstrap4.js
@@ -65,7 +65,8 @@ JSONEditor.defaults.themes.bootstrap4 = JSONEditor.AbstractTheme.extend({
   getFormInputDescription: function(text) {
     var el = document.createElement("p");
     el.classList.add('form-text');
-    el.innerHTML = text;
+    if (window.DOMPurify) el.innerHTML = text;
+    else el.textContent = text;
     return el;
   },
   getHeaderButtonHolder: function() {

--- a/src/themes/bootstrap4.js
+++ b/src/themes/bootstrap4.js
@@ -65,7 +65,7 @@ JSONEditor.defaults.themes.bootstrap4 = JSONEditor.AbstractTheme.extend({
   getFormInputDescription: function(text) {
     var el = document.createElement("p");
     el.classList.add('form-text');
-    if (window.DOMPurify) el.innerHTML = text;
+    if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
     else el.textContent = text;
     return el;
   },

--- a/src/themes/foundation.js
+++ b/src/themes/foundation.js
@@ -42,7 +42,8 @@ JSONEditor.defaults.themes.foundation = JSONEditor.AbstractTheme.extend({
   },
   getFormInputDescription: function(text) {
     var el = document.createElement('p');
-    el.textContent = text;
+    if (window.DOMPurify) el.innerHTML = text;
+    else el.textContent = text;
     el.style.marginTop = '-10px';
     el.style.fontStyle = 'italic';
     return el;

--- a/src/themes/foundation.js
+++ b/src/themes/foundation.js
@@ -42,7 +42,7 @@ JSONEditor.defaults.themes.foundation = JSONEditor.AbstractTheme.extend({
   },
   getFormInputDescription: function(text) {
     var el = document.createElement('p');
-    if (window.DOMPurify) el.innerHTML = text;
+    if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
     else el.textContent = text;
     el.style.marginTop = '-10px';
     el.style.fontStyle = 'italic';

--- a/src/themes/jqueryui.js
+++ b/src/themes/jqueryui.js
@@ -45,7 +45,7 @@ JSONEditor.defaults.themes.jqueryui = JSONEditor.AbstractTheme.extend({
     var el = document.createElement('span');
     el.style.fontSize = '.8em';
     el.style.fontStyle = 'italic';
-    if (window.DOMPurify) el.innerHTML = text;
+    if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
     else el.textContent = text;
     return el;
   },

--- a/src/themes/jqueryui.js
+++ b/src/themes/jqueryui.js
@@ -45,7 +45,8 @@ JSONEditor.defaults.themes.jqueryui = JSONEditor.AbstractTheme.extend({
     var el = document.createElement('span');
     el.style.fontSize = '.8em';
     el.style.fontStyle = 'italic';
-    el.textContent = text;
+    if (window.DOMPurify) el.innerHTML = text;
+    else el.textContent = text;
     return el;
   },
   getButtonHolder: function() {

--- a/src/themes/materialize.js
+++ b/src/themes/materialize.js
@@ -126,7 +126,8 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
       var el = document.createElement('div');
       el.classList.add('grey-text');
       el.style.marginTop = '-15px';
-      el.innerHTML = text;
+      if (window.DOMPurify) el.innerHTML = text;
+      else el.textContent = text;
       return el;
     },
 

--- a/src/themes/materialize.js
+++ b/src/themes/materialize.js
@@ -126,7 +126,7 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
       var el = document.createElement('div');
       el.classList.add('grey-text');
       el.style.marginTop = '-15px';
-      if (window.DOMPurify) el.innerHTML = text;
+      if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
       else el.textContent = text;
       return el;
     },


### PR DESCRIPTION
If [DOMPurify](https://github.com/cure53/DOMPurify) library is loaded, themes can render description as HTML text. Otherwise description is rendered as plain text.