### PR TITLE
Fix of #326

### DIFF
--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -266,7 +266,7 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
       var output = document.createElement('output');
       output.setAttribute('class', 'range-output');
       this.control.appendChild(output);
-      output.value = this.schema.default || this.schema.minimum || 0;
+      output.value = this.schema.default || Math.max(this.schema.minimum || 0, 0);
       this.input.addEventListener('change', function () {
         output.value = self.input.value;
       });

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -266,7 +266,7 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
       var output = document.createElement('output');
       output.setAttribute('class', 'range-output');
       this.control.appendChild(output);
-      output.value = this.schema.default || 0;
+      output.value = this.schema.default || this.schema.minimum || 0;
       this.input.addEventListener('change', function () {
         output.value = self.input.value;
       });

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -266,7 +266,7 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
       var output = document.createElement('output');
       output.setAttribute('class', 'range-output');
       this.control.appendChild(output);
-      output.value = this.schema.default;
+      output.value = this.schema.default || 0;
       this.input.addEventListener('change', function () {
         output.value = self.input.value;
       });


### PR DESCRIPTION
Defaults to "0" if no default value is set. Then value matches initial slider position.
Example Schema
````json
{
  "type": "object",
  "required": ["grade"],
  "properties": {
    "grade": {
      "type": "integer",
      "format": "range",
      "maximum": 10,
      "minimum": -10
    }
  },
  "title": "Student"
}
````