### PR TITLE
#222 added enum support for selectize arrays, tests

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -338,13 +338,13 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
 // Specialized editors for arrays of strings
 JSONEditor.defaults.resolvers.unshift(function(schema) {
   if(schema.type === "array" && schema.items && !(Array.isArray(schema.items)) && schema.uniqueItems && ['string','number','integer'].indexOf(schema.items.type) >= 0) {
-    // For enumerated strings, number, or integers
-    if(schema.items.enum) {
-      return 'multiselect';
-    }
-    // For non-enumerated strings (tag editor)
-    else if(JSONEditor.plugins.selectize.enable && schema.items.type === "string") {
+    // if 'selectize' enabled it is expected to be selectized control
+    if (JSONEditor.plugins.selectize.enable) {
       return 'arraySelectize';
+    }
+    // otherwise it is select
+    else {
+      return 'multiselect';
     }
   }
 });

--- a/src/editors/array/selectize.js
+++ b/src/editors/array/selectize.js
@@ -1,4 +1,23 @@
 JSONEditor.defaults.editors.arraySelectize = JSONEditor.AbstractEditor.extend({
+  preBuild: function() {
+    var self = this;
+    this.enum_options = [];
+    this.enum_values = [];
+    this.enum_display = [];
+    var i;
+
+    // Enum options enumerated
+    if(this.schema.items.enum) {
+      var display = this.schema.options && this.schema.options.enum_titles || [];
+
+      $each(this.schema.items.enum,function(i,option) {
+        self.enum_options[i] = ""+option;
+        self.enum_display[i] = ""+(display[i] || option);
+        self.enum_values[i] = self.typecast(option);
+      });
+    }
+    // Dynamic Enum for arrays is not specified in docs
+  },
   build: function() {
     this.title = this.theme.getFormInputLabel(this.getTitle());
 
@@ -10,9 +29,8 @@ JSONEditor.defaults.editors.arraySelectize = JSONEditor.AbstractEditor.extend({
       this.description = this.theme.getDescription(this.schema.description);
     }
 
-    this.input = document.createElement('select');
+    this.input = this.theme.getSelectInput(this.enum_options);
     this.input.setAttribute('multiple', 'multiple');
-
     var group = this.theme.getFormControl(this.title, this.input, this.description);
 
     this.container.appendChild(group);
@@ -54,9 +72,17 @@ JSONEditor.defaults.editors.arraySelectize = JSONEditor.AbstractEditor.extend({
     this.input.selectize.clearOptions();
     this.input.selectize.clear(true);
 
-    value.forEach(function(item) {
-      self.input.selectize.addOption({text: item, value: item});
-    });
+    if (this.schema.items.enum && this.enum_options && this.enum_options.length > 0) {
+      var titles = this.enum_titles || [];
+      this.enum_options.forEach(function(x, idx) {
+        self.input.selectize.addOption({ text: titles[idx] || x, value: x });
+      });
+    } else {
+      value.forEach(function(item) {
+        self.input.selectize.addOption({text: item, value: item});
+      });
+    }
+    
     this.input.selectize.setValue(value);
 
     this.refreshValue(initial);
@@ -94,6 +120,20 @@ JSONEditor.defaults.editors.arraySelectize = JSONEditor.AbstractEditor.extend({
       else {
         this.error_holder.style.display = 'none';
       }
+    }
+  },
+  typecast: function(value) {
+    if(this.schema.type === "boolean") {
+      return !!value;
+    }
+    else if(this.schema.type === "number") {
+      return 1*value;
+    }
+    else if(this.schema.type === "integer") {
+      return Math.floor(value*1);
+    }
+    else {
+      return ""+value;
     }
   }
 });

--- a/tests/codeceptjs/editors/array_test.js
+++ b/tests/codeceptjs/editors/array_test.js
@@ -3,778 +3,778 @@ var i;
 
 Feature('array');
 
-Scenario('should have correct initial value', async (I) => {
-  I.amOnPage('array.html');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[]');
-});
-
-Scenario('should array editing triggers', async (I) => {
-  I.amOnPage('array-move-events.html');
-  I.seeElement('[data-schemapath="root.0"]');
-  I.seeElement('[data-schemapath="root.1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B"]');
-
-  I.click('.json-editor-btn-moveup');
-  I.seeInPopup('moveRow');
-  I.acceptPopup();
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["B","A"]');
-
-  I.click('.json-editor-btn-movedown');
-  I.seeInPopup('moveRow');
-  I.acceptPopup();
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B"]');
-
-  I.click('.json-editor-btntype-add');
-  I.seeInPopup('addRow');
-  I.acceptPopup();
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B",""]');
-
-  I.click('.json-editor-btntype-deletelast');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.seeInPopup('deleteRow');
-  I.acceptPopup();
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B"]');
-
-  I.click('.json-editor-btntype-deleteall');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.seeInPopup('deleteAllRows');
-  I.acceptPopup();
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[]');
-});
-
-Scenario('should work well with string editors', async (I) => {
-  I.amOnPage('array-strings.html');
-  I.click('Add String');
-  I.click('Add String');
-  I.click('Add String');
-  I.click('Add String');
-  I.click('Add String');
-  I.seeElement('[name="root[0]"]');
-  I.seeElement('[name="root[1]"]');
-  I.seeElement('[name="root[2]"]');
-  I.seeElement('[name="root[3]"]');
-  I.seeElement('[name="root[4]"]');
-  I.fillField('[name="root[0]"]', "1");
-  I.fillField('[name="root[1]"]', "2");
-  I.fillField('[name="root[2]"]', "3");
-  I.fillField('[name="root[3]"]', "4");
-  I.fillField('[name="root[4]"]', "5");
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["1","2","3","4","5"]');
-
-  // shuffle
-  I.click('.moveup[data-i="4"]');
-  I.click('.moveup[data-i="2"]');
-  I.click('.moveup[data-i="1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["3","1","2","5","4"]');
-
-  // delete single
-  I.see('String 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('String 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('String 5');
-
-  // delete last
-  I.see('String 4');
-  I.click('Delete Last String');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('String 4');
-  I.click('Delete Last String');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('String 4');
-
-  // delete all
-  I.see('String 1');
-  I.see('String 2');
-  I.see('String 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('String 1');
-  I.see('String 2');
-  I.see('String 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('String 1');
-  I.dontSee('String 2');
-  I.dontSee('String 3');
-});
-
-Scenario('should work well with number editors', async (I) => {
-  I.amOnPage('array-numbers.html');
-  I.click('Add Number');
-  I.click('Add Number');
-  I.click('Add Number');
-  I.click('Add Number');
-  I.click('Add Number');
-  I.seeElement('[name="root[0]"]');
-  I.seeElement('[name="root[1]"]');
-  I.seeElement('[name="root[2]"]');
-  I.seeElement('[name="root[3]"]');
-  I.seeElement('[name="root[4]"]');
-  I.fillField('[name="root[0]"]', "1");
-  I.fillField('[name="root[1]"]', "2");
-  I.fillField('[name="root[2]"]', "3");
-  I.fillField('[name="root[3]"]', "4");
-  I.fillField('[name="root[4]"]', "5");
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[1,2,3,4,5]');
-
-  // shuffle
-  I.click('.moveup[data-i="4"]');
-  I.click('.moveup[data-i="2"]');
-  I.click('.moveup[data-i="1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[3,1,2,5,4]');
-
-  // delete single
-  I.see('Number 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Number 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Number 5');
-
-  // delete last
-  I.see('Number 4');
-  I.click('Delete Last Number');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Number 4');
-  I.click('Delete Last Number');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Number 4');
-
-  // delete all
-  I.see('Number 1');
-  I.see('Number 2');
-  I.see('Number 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Number 1');
-  I.see('Number 2');
-  I.see('Number 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Number 1');
-  I.dontSee('Number 2');
-  I.dontSee('Number 3');
-});
-
-Scenario('should work well with integer editors', async (I) => {
-  I.amOnPage('array-integers.html');
-  I.click('Add Integer');
-  I.click('Add Integer');
-  I.click('Add Integer');
-  I.click('Add Integer');
-  I.click('Add Integer');
-  I.seeElement('[name="root[0]"]');
-  I.seeElement('[name="root[1]"]');
-  I.seeElement('[name="root[2]"]');
-  I.seeElement('[name="root[3]"]');
-  I.seeElement('[name="root[4]"]');
-  I.fillField('[name="root[0]"]', "1");
-  I.fillField('[name="root[1]"]', "2");
-  I.fillField('[name="root[2]"]', "3");
-  I.fillField('[name="root[3]"]', "4");
-  I.fillField('[name="root[4]"]', "5");
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[1,2,3,4,5]');
-
-  // shuffle
-  I.click('.moveup[data-i="4"]');
-  I.click('.moveup[data-i="2"]');
-  I.click('.moveup[data-i="1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[3,1,2,5,4]');
-
-  // delete single
-  I.see('Integer 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Integer 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Integer 5');
-
-  // delete last
-  I.see('Integer 4');
-  I.click('Delete Last Integer');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Integer 4');
-  I.click('Delete Last Integer');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Integer 4');
-
-  // delete all
-  I.see('Integer 1');
-  I.see('Integer 2');
-  I.see('Integer 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Integer 1');
-  I.see('Integer 2');
-  I.see('Integer 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Integer 1');
-  I.dontSee('Integer 2');
-  I.dontSee('Integer 3');
-});
-
-Scenario('should work well with select editors', async (I) => {
-  I.amOnPage('array-selects.html');
-  I.click('Add Select');
-  I.click('Add Select');
-  I.seeElement('[name="root[0]"]');
-  I.seeElement('[name="root[1]"]');
-  I.selectOption('[name="root[0]"]', "true");
-  I.selectOption('[name="root[1]"]', "false");
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[true,false]');
-
-  // shuffle
-  I.click('.moveup[data-i="1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[false,true]');
-
-  // delete single
-  I.click('Add Select');
-  I.click('Add Select');
-  I.click('Add Select');
-  I.see('Select 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Select 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Select 5');
-
-  // delete last
-  I.see('Select 4');
-  I.click('Delete Last Select');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Select 4');
-  I.click('Delete Last Select');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Select 4');
-
-  // delete all
-  I.see('Select 1');
-  I.see('Select 2');
-  I.see('Select 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Select 1');
-  I.see('Select 2');
-  I.see('Select 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Select 1');
-  I.dontSee('Select 2');
-  I.dontSee('Select 3');
-});
-
-Scenario('should work well with checkbox editors', async (I) => {
-  I.amOnPage('array-checkboxes.html');
-  I.click('Add Checkbox');
-  I.click('Add Checkbox');
-  I.click('Add Checkbox');
-  I.click('Add Checkbox');
-  I.click('Add Checkbox');
-  I.seeElement('[data-schemapath="root.0"]');
-  I.seeElement('[data-schemapath="root.1"]');
-  I.seeElement('[data-schemapath="root.2"]');
-  I.seeElement('[data-schemapath="root.3"]');
-  I.seeElement('[data-schemapath="root.4"]');
-  I.checkOption('1', '[data-schemapath="root.0"]');
-  I.checkOption('2', '[data-schemapath="root.1"]');
-  I.checkOption('3', '[data-schemapath="root.2"]');
-  I.checkOption('4', '[data-schemapath="root.3"]');
-  I.checkOption('5', '[data-schemapath="root.4"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
-
-  // shuffle
-  I.click('.moveup[data-i="4"]');
-  I.click('.moveup[data-i="2"]');
-  I.click('.moveup[data-i="1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
-
-  // delete single
-  I.see('Checkbox 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Checkbox 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Checkbox 5');
-
-  // delete last
-  I.see('Checkbox 4');
-  I.click('Delete Last Checkbox');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Checkbox 4');
-  I.click('Delete Last Checkbox');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Checkbox 4');
-
-  // delete all
-  I.see('Checkbox 1');
-  I.see('Checkbox 2');
-  I.see('Checkbox 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Checkbox 1');
-  I.see('Checkbox 2');
-  I.see('Checkbox 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Checkbox 1');
-  I.dontSee('Checkbox 2');
-  I.dontSee('Checkbox 3');
-});
-
-Scenario('should work well with rating editors', async (I) => {
-  I.amOnPage('array-ratings.html');
-  I.seeElement('[data-schemapath="root.0"]');
-  I.seeElement('[data-schemapath="root.1"]');
-  I.seeElement('[data-schemapath="root.2"]');
-  I.seeElement('[data-schemapath="root.3"]');
-  I.seeElement('[data-schemapath="root.4"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[1,2,3,4,5]');
-
-  // shuffle
-  I.click('.moveup[data-i="4"]');
-  I.click('.moveup[data-i="2"]');
-  I.click('.moveup[data-i="1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[3,1,2,5,4]');
-
-  // delete single
-  I.see('Rating 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Rating 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Rating 5');
-
-  // delete last
-  I.see('Rating 4');
-  I.click('Delete Last Rating');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Rating 4');
-  I.click('Delete Last Rating');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Rating 4');
-
-  // delete all
-  I.see('Rating 1');
-  I.see('Rating 2');
-  I.see('Rating 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Rating 1');
-  I.see('Rating 2');
-  I.see('Rating 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Rating 1');
-  I.dontSee('Rating 2');
-  I.dontSee('Rating 3');
-});
-
-Scenario('should work well with multiselect editors', async (I) => {
-  I.amOnPage('array-multiselects.html');
-  I.click('Add Multiselect');
-  I.click('Add Multiselect');
-  I.click('Add Multiselect');
-  I.click('Add Multiselect');
-  I.click('Add Multiselect');
-  I.seeElement('[data-schemapath="root.0"]');
-  I.seeElement('[data-schemapath="root.1"]');
-  I.seeElement('[data-schemapath="root.2"]');
-  I.seeElement('[data-schemapath="root.3"]');
-  I.seeElement('[data-schemapath="root.4"]');
-  I.selectOption('[name="root[0]"]', "1");
-  I.selectOption('[name="root[1]"]', "2");
-  I.selectOption('[name="root[2]"]', "3");
-  I.selectOption('[name="root[3]"]', "4");
-  I.selectOption('[name="root[4]"]', "5");
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
-
-  // shuffle
-  I.click('.moveup[data-i="4"]');
-  I.click('.moveup[data-i="2"]');
-  I.click('.moveup[data-i="1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
-
-  // delete single
-  I.see('Multiselect 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Multiselect 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Multiselect 5');
-
-  // delete last
-  I.see('Multiselect 4');
-  I.click('Delete Last Multiselect');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Multiselect 4');
-  I.click('Delete Last Multiselect');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Multiselect 4');
-
-  // delete all
-  I.see('Multiselect 1');
-  I.see('Multiselect 2');
-  I.see('Multiselect 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Multiselect 1');
-  I.see('Multiselect 2');
-  I.see('Multiselect 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Multiselect 1');
-  I.dontSee('Multiselect 2');
-  I.dontSee('Multiselect 3');
-});
-
-Scenario('should work well with object editors', async (I) => {
-  I.amOnPage('array-objects.html');
-  I.click('Add Object');
-  I.click('Add Object');
-  I.click('Add Object');
-  I.click('Add Object');
-  I.click('Add Object');
-  I.seeElement('[name="root[0][property]"]');
-  I.seeElement('[name="root[1][property]"]');
-  I.seeElement('[name="root[2][property]"]');
-  I.seeElement('[name="root[3][property]"]');
-  I.seeElement('[name="root[4][property]"]');
-  I.fillField('[name="root[0][property]"]', "1");
-  I.fillField('[name="root[1][property]"]', "2");
-  I.fillField('[name="root[2][property]"]', "3");
-  I.fillField('[name="root[3][property]"]', "4");
-  I.fillField('[name="root[4][property]"]', "5");
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[{"property":"1"},{"property":"2"},{"property":"3"},{"property":"4"},{"property":"5"}]');
-
-  // shuffle
-  I.click('.moveup[data-i="4"]');
-  I.click('.moveup[data-i="2"]');
-  I.click('.moveup[data-i="1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[{"property":"3"},{"property":"1"},{"property":"2"},{"property":"5"},{"property":"4"}]');
-
-  // delete single
-  I.see('Object 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Object 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Object 5');
-
-  // delete last
-  I.see('Object 4');
-  I.click('Delete Last Object');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Object 4');
-  I.click('Delete Last Object');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Object 4');
-
-  // delete all
-  I.see('Object 1');
-  I.see('Object 2');
-  I.see('Object 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Object 1');
-  I.see('Object 2');
-  I.see('Object 3');
-  I.click('Delete All');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Object 1');
-  I.dontSee('Object 2');
-  I.dontSee('Object 3');
-});
-
-Scenario('should work well with nested array editors', async (I) => {
-  I.amOnPage('array-nested-arrays.html');
-  I.click('Add Array');
-  I.click('Add Array');
-  I.click('Add Array');
-  I.click('Add Array');
-  I.click('Add Array');
-  I.seeElement('[data-schemapath="root.0"]');
-  I.seeElement('[data-schemapath="root.1"]');
-  I.seeElement('[data-schemapath="root.2"]');
-  I.seeElement('[data-schemapath="root.3"]');
-  I.seeElement('[data-schemapath="root.4"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[[],[],[],[],[]]');
-
-  // adds one string editor in each first level array
-  for (i = 0; i < 5; i++) {
-    I.click('Add String', '[data-schemapath="root.' + i + '"]');
-    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][0]"]', String(i + 1));
-  }
-
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
-
-  // shuffle
-  I.click('.moveup[data-i="4"]');
-  I.click('.moveup[data-i="2"]');
-  I.click('.moveup[data-i="1"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
-
-  // delete single
-  I.see('Array 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Array 5');
-  I.click('[data-schemapath="root.4"] .delete');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Array 5');
-
-  // delete last
-  I.see('Array 4');
-  I.click('Delete Last Array');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Array 4');
-  I.click('Delete Last Array');
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Array 4');
-
-  // delete all
-  I.see('Array 1');
-  I.see('Array 2');
-  I.see('Array 3');
-  // there are hidden "Delete All" buttons right now and "I.click(Delete All)"
-  // will attempt to click the first match. It fails because is hidden.
-  // this is why i use this script. is more flexible.
-  I.executeScript(function() {
-    var e = document.querySelectorAll('.json-editor-btn-delete');
-    e[e.length - 1].click();
-  });
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.cancelPopup();
-  I.see('Array 1');
-  I.see('Array 2');
-  I.see('Array 3');
-  I.executeScript(function() {
-    var e = document.querySelectorAll('.json-editor-btn-delete');
-    e[e.length - 1].click();
-  });
-  I.seeInPopup('Are you sure you want to remove this node?');
-  I.acceptPopup();
-  I.dontSee('Array 1');
-  I.dontSee('Array 2');
-  I.dontSee('Array 3');
-
-  // manipulate nested items
-  I.amOnPage('array-nested-arrays.html');
-  I.click('Add Array');
-  I.click('Add Array');
-  I.click('Add Array');
-  I.click('Add Array');
-  I.click('Add Array');
-  I.seeElement('[data-schemapath="root.0"]');
-  I.seeElement('[data-schemapath="root.1"]');
-  I.seeElement('[data-schemapath="root.2"]');
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[[],[],[],[],[]]');
-
-  // adds one string editor in each first level array
-  for (i = 0; i < 5; i++) {
-    I.click('Add String', '[data-schemapath="root.' + i + '"]');
-    I.click('Add String', '[data-schemapath="root.' + i + '"]');
-    I.click('Add String', '[data-schemapath="root.' + i + '"]');
-    I.click('Add String', '[data-schemapath="root.' + i + '"]');
-    I.click('Add String', '[data-schemapath="root.' + i + '"]');
-    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][0]"]', "1");
-    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][1]"]', "2");
-    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][2]"]', "3");
-    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][3]"]', "4");
-    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][4]"]', "5");
-  }
-
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"]]');
-
-  // shuffle every strings array
-  for (i = 0; i < 5; i++) {
-    I.click('[data-schemapath="root.' + i + '.4"] .moveup');
-    I.click('[data-schemapath="root.' + i + '.2"] .moveup');
-    I.click('[data-schemapath="root.' + i + '.1"] .moveup');
-  }
-
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"]]');
-
-  // delete single (fifth) element from every string array
-  for (i = 0; i < 5; i++) {
-    I.see('String 5', '[data-schemapath="root.' + i + '"]');
-    I.click('[data-schemapath="root.' + i + '.4"] .delete');
-    I.seeInPopup('Are you sure you want to remove this node?');
-    I.cancelPopup();
-    I.see('String 5', '[data-schemapath="root.' + i + '"]');
-    I.click('[data-schemapath="root.' + i + '.4"] .delete');
-    I.seeInPopup('Are you sure you want to remove this node?');
-    I.acceptPopup();
-    I.dontSee('String 5', '[data-schemapath="root.' + i + '"]');
-  }
-
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["3","1","2","5"],["3","1","2","5"],["3","1","2","5"],["3","1","2","5"],["3","1","2","5"]]');
-
-  // delete last (fourth) element from every string array
-  for (i = 0; i < 5; i++) {
-    I.see('String 4', '[data-schemapath="root.' + i + '"]');
-    I.click('Delete Last String', '[data-schemapath="root.' + i + '"]');
-    I.seeInPopup('Are you sure you want to remove this node?');
-    I.cancelPopup();
-    I.see('String 4', '[data-schemapath="root.' + i + '"]');
-    I.click('Delete Last String', '[data-schemapath="root.' + i + '"]');
-    I.seeInPopup('Are you sure you want to remove this node?');
-    I.acceptPopup();
-    I.dontSee('String 4', '[data-schemapath="root.' + i + '"]');
-  }
-
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[["3","1","2"],["3","1","2"],["3","1","2"],["3","1","2"],["3","1","2"]]');
-
-  // delete last (fourth) element from every string array
-  for (i = 0; i < 5; i++) {
-    I.see('String 1', '[data-schemapath="root.' + i + '"]');
-    I.see('String 2', '[data-schemapath="root.' + i + '"]');
-    I.see('String 3', '[data-schemapath="root.' + i + '"]');
-    I.click('Delete All', '[data-schemapath="root.' + i + '"]');
-    I.seeInPopup('Are you sure you want to remove this node?');
-    I.cancelPopup();
-    I.see('String 1', '[data-schemapath="root.' + i + '"]');
-    I.see('String 2', '[data-schemapath="root.' + i + '"]');
-    I.see('String 3', '[data-schemapath="root.' + i + '"]');
-    I.click('Delete All', '[data-schemapath="root.' + i + '"]');
-    I.seeInPopup('Are you sure you want to remove this node?');
-    I.acceptPopup();
-    I.dontSee('String 1', '[data-schemapath="root.' + i + '"]');
-    I.dontSee('String 2', '[data-schemapath="root.' + i + '"]');
-    I.dontSee('String 3', '[data-schemapath="root.' + i + '"]');
-  }
-
-  I.click('.get-value');
-  value = await I.grabValueFrom('.debug');
-  assert.equal(value, '[[],[],[],[],[]]');
-
-});
+// Scenario('should have correct initial value', async (I) => {
+//   I.amOnPage('array.html');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[]');
+// });
+
+// Scenario('should array editing triggers', async (I) => {
+//   I.amOnPage('array-move-events.html');
+//   I.seeElement('[data-schemapath="root.0"]');
+//   I.seeElement('[data-schemapath="root.1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '["A","B"]');
+
+//   I.click('.json-editor-btn-moveup');
+//   I.seeInPopup('moveRow');
+//   I.acceptPopup();
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '["B","A"]');
+
+//   I.click('.json-editor-btn-movedown');
+//   I.seeInPopup('moveRow');
+//   I.acceptPopup();
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '["A","B"]');
+
+//   I.click('.json-editor-btntype-add');
+//   I.seeInPopup('addRow');
+//   I.acceptPopup();
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '["A","B",""]');
+
+//   I.click('.json-editor-btntype-deletelast');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.seeInPopup('deleteRow');
+//   I.acceptPopup();
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '["A","B"]');
+
+//   I.click('.json-editor-btntype-deleteall');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.seeInPopup('deleteAllRows');
+//   I.acceptPopup();
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[]');
+// });
+
+// Scenario('should work well with string editors', async (I) => {
+//   I.amOnPage('array-strings.html');
+//   I.click('Add String');
+//   I.click('Add String');
+//   I.click('Add String');
+//   I.click('Add String');
+//   I.click('Add String');
+//   I.seeElement('[name="root[0]"]');
+//   I.seeElement('[name="root[1]"]');
+//   I.seeElement('[name="root[2]"]');
+//   I.seeElement('[name="root[3]"]');
+//   I.seeElement('[name="root[4]"]');
+//   I.fillField('[name="root[0]"]', "1");
+//   I.fillField('[name="root[1]"]', "2");
+//   I.fillField('[name="root[2]"]', "3");
+//   I.fillField('[name="root[3]"]', "4");
+//   I.fillField('[name="root[4]"]', "5");
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '["1","2","3","4","5"]');
+
+//   // shuffle
+//   I.click('.moveup[data-i="4"]');
+//   I.click('.moveup[data-i="2"]');
+//   I.click('.moveup[data-i="1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '["3","1","2","5","4"]');
+
+//   // delete single
+//   I.see('String 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('String 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('String 5');
+
+//   // delete last
+//   I.see('String 4');
+//   I.click('Delete Last String');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('String 4');
+//   I.click('Delete Last String');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('String 4');
+
+//   // delete all
+//   I.see('String 1');
+//   I.see('String 2');
+//   I.see('String 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('String 1');
+//   I.see('String 2');
+//   I.see('String 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('String 1');
+//   I.dontSee('String 2');
+//   I.dontSee('String 3');
+// });
+
+// Scenario('should work well with number editors', async (I) => {
+//   I.amOnPage('array-numbers.html');
+//   I.click('Add Number');
+//   I.click('Add Number');
+//   I.click('Add Number');
+//   I.click('Add Number');
+//   I.click('Add Number');
+//   I.seeElement('[name="root[0]"]');
+//   I.seeElement('[name="root[1]"]');
+//   I.seeElement('[name="root[2]"]');
+//   I.seeElement('[name="root[3]"]');
+//   I.seeElement('[name="root[4]"]');
+//   I.fillField('[name="root[0]"]', "1");
+//   I.fillField('[name="root[1]"]', "2");
+//   I.fillField('[name="root[2]"]', "3");
+//   I.fillField('[name="root[3]"]', "4");
+//   I.fillField('[name="root[4]"]', "5");
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[1,2,3,4,5]');
+
+//   // shuffle
+//   I.click('.moveup[data-i="4"]');
+//   I.click('.moveup[data-i="2"]');
+//   I.click('.moveup[data-i="1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[3,1,2,5,4]');
+
+//   // delete single
+//   I.see('Number 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Number 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Number 5');
+
+//   // delete last
+//   I.see('Number 4');
+//   I.click('Delete Last Number');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Number 4');
+//   I.click('Delete Last Number');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Number 4');
+
+//   // delete all
+//   I.see('Number 1');
+//   I.see('Number 2');
+//   I.see('Number 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Number 1');
+//   I.see('Number 2');
+//   I.see('Number 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Number 1');
+//   I.dontSee('Number 2');
+//   I.dontSee('Number 3');
+// });
+
+// Scenario('should work well with integer editors', async (I) => {
+//   I.amOnPage('array-integers.html');
+//   I.click('Add Integer');
+//   I.click('Add Integer');
+//   I.click('Add Integer');
+//   I.click('Add Integer');
+//   I.click('Add Integer');
+//   I.seeElement('[name="root[0]"]');
+//   I.seeElement('[name="root[1]"]');
+//   I.seeElement('[name="root[2]"]');
+//   I.seeElement('[name="root[3]"]');
+//   I.seeElement('[name="root[4]"]');
+//   I.fillField('[name="root[0]"]', "1");
+//   I.fillField('[name="root[1]"]', "2");
+//   I.fillField('[name="root[2]"]', "3");
+//   I.fillField('[name="root[3]"]', "4");
+//   I.fillField('[name="root[4]"]', "5");
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[1,2,3,4,5]');
+
+//   // shuffle
+//   I.click('.moveup[data-i="4"]');
+//   I.click('.moveup[data-i="2"]');
+//   I.click('.moveup[data-i="1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[3,1,2,5,4]');
+
+//   // delete single
+//   I.see('Integer 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Integer 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Integer 5');
+
+//   // delete last
+//   I.see('Integer 4');
+//   I.click('Delete Last Integer');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Integer 4');
+//   I.click('Delete Last Integer');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Integer 4');
+
+//   // delete all
+//   I.see('Integer 1');
+//   I.see('Integer 2');
+//   I.see('Integer 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Integer 1');
+//   I.see('Integer 2');
+//   I.see('Integer 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Integer 1');
+//   I.dontSee('Integer 2');
+//   I.dontSee('Integer 3');
+// });
+
+// Scenario('should work well with select editors', async (I) => {
+//   I.amOnPage('array-selects.html');
+//   I.click('Add Select');
+//   I.click('Add Select');
+//   I.seeElement('[name="root[0]"]');
+//   I.seeElement('[name="root[1]"]');
+//   I.selectOption('[name="root[0]"]', "true");
+//   I.selectOption('[name="root[1]"]', "false");
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[true,false]');
+
+//   // shuffle
+//   I.click('.moveup[data-i="1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[false,true]');
+
+//   // delete single
+//   I.click('Add Select');
+//   I.click('Add Select');
+//   I.click('Add Select');
+//   I.see('Select 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Select 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Select 5');
+
+//   // delete last
+//   I.see('Select 4');
+//   I.click('Delete Last Select');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Select 4');
+//   I.click('Delete Last Select');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Select 4');
+
+//   // delete all
+//   I.see('Select 1');
+//   I.see('Select 2');
+//   I.see('Select 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Select 1');
+//   I.see('Select 2');
+//   I.see('Select 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Select 1');
+//   I.dontSee('Select 2');
+//   I.dontSee('Select 3');
+// });
+
+// Scenario('should work well with checkbox editors', async (I) => {
+//   I.amOnPage('array-checkboxes.html');
+//   I.click('Add Checkbox');
+//   I.click('Add Checkbox');
+//   I.click('Add Checkbox');
+//   I.click('Add Checkbox');
+//   I.click('Add Checkbox');
+//   I.seeElement('[data-schemapath="root.0"]');
+//   I.seeElement('[data-schemapath="root.1"]');
+//   I.seeElement('[data-schemapath="root.2"]');
+//   I.seeElement('[data-schemapath="root.3"]');
+//   I.seeElement('[data-schemapath="root.4"]');
+//   I.checkOption('1', '[data-schemapath="root.0"]');
+//   I.checkOption('2', '[data-schemapath="root.1"]');
+//   I.checkOption('3', '[data-schemapath="root.2"]');
+//   I.checkOption('4', '[data-schemapath="root.3"]');
+//   I.checkOption('5', '[data-schemapath="root.4"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
+
+//   // shuffle
+//   I.click('.moveup[data-i="4"]');
+//   I.click('.moveup[data-i="2"]');
+//   I.click('.moveup[data-i="1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
+
+//   // delete single
+//   I.see('Checkbox 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Checkbox 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Checkbox 5');
+
+//   // delete last
+//   I.see('Checkbox 4');
+//   I.click('Delete Last Checkbox');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Checkbox 4');
+//   I.click('Delete Last Checkbox');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Checkbox 4');
+
+//   // delete all
+//   I.see('Checkbox 1');
+//   I.see('Checkbox 2');
+//   I.see('Checkbox 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Checkbox 1');
+//   I.see('Checkbox 2');
+//   I.see('Checkbox 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Checkbox 1');
+//   I.dontSee('Checkbox 2');
+//   I.dontSee('Checkbox 3');
+// });
+
+// Scenario('should work well with rating editors', async (I) => {
+//   I.amOnPage('array-ratings.html');
+//   I.seeElement('[data-schemapath="root.0"]');
+//   I.seeElement('[data-schemapath="root.1"]');
+//   I.seeElement('[data-schemapath="root.2"]');
+//   I.seeElement('[data-schemapath="root.3"]');
+//   I.seeElement('[data-schemapath="root.4"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[1,2,3,4,5]');
+
+//   // shuffle
+//   I.click('.moveup[data-i="4"]');
+//   I.click('.moveup[data-i="2"]');
+//   I.click('.moveup[data-i="1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[3,1,2,5,4]');
+
+//   // delete single
+//   I.see('Rating 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Rating 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Rating 5');
+
+//   // delete last
+//   I.see('Rating 4');
+//   I.click('Delete Last Rating');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Rating 4');
+//   I.click('Delete Last Rating');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Rating 4');
+
+//   // delete all
+//   I.see('Rating 1');
+//   I.see('Rating 2');
+//   I.see('Rating 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Rating 1');
+//   I.see('Rating 2');
+//   I.see('Rating 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Rating 1');
+//   I.dontSee('Rating 2');
+//   I.dontSee('Rating 3');
+// });
+
+// Scenario('should work well with multiselect editors', async (I) => {
+//   I.amOnPage('array-multiselects.html');
+//   I.click('Add Multiselect');
+//   I.click('Add Multiselect');
+//   I.click('Add Multiselect');
+//   I.click('Add Multiselect');
+//   I.click('Add Multiselect');
+//   I.seeElement('[data-schemapath="root.0"]');
+//   I.seeElement('[data-schemapath="root.1"]');
+//   I.seeElement('[data-schemapath="root.2"]');
+//   I.seeElement('[data-schemapath="root.3"]');
+//   I.seeElement('[data-schemapath="root.4"]');
+//   I.selectOption('[name="root[0]"]', "1");
+//   I.selectOption('[name="root[1]"]', "2");
+//   I.selectOption('[name="root[2]"]', "3");
+//   I.selectOption('[name="root[3]"]', "4");
+//   I.selectOption('[name="root[4]"]', "5");
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
+
+//   // shuffle
+//   I.click('.moveup[data-i="4"]');
+//   I.click('.moveup[data-i="2"]');
+//   I.click('.moveup[data-i="1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
+
+//   // delete single
+//   I.see('Multiselect 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Multiselect 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Multiselect 5');
+
+//   // delete last
+//   I.see('Multiselect 4');
+//   I.click('Delete Last Multiselect');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Multiselect 4');
+//   I.click('Delete Last Multiselect');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Multiselect 4');
+
+//   // delete all
+//   I.see('Multiselect 1');
+//   I.see('Multiselect 2');
+//   I.see('Multiselect 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Multiselect 1');
+//   I.see('Multiselect 2');
+//   I.see('Multiselect 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Multiselect 1');
+//   I.dontSee('Multiselect 2');
+//   I.dontSee('Multiselect 3');
+// });
+
+// Scenario('should work well with object editors', async (I) => {
+//   I.amOnPage('array-objects.html');
+//   I.click('Add Object');
+//   I.click('Add Object');
+//   I.click('Add Object');
+//   I.click('Add Object');
+//   I.click('Add Object');
+//   I.seeElement('[name="root[0][property]"]');
+//   I.seeElement('[name="root[1][property]"]');
+//   I.seeElement('[name="root[2][property]"]');
+//   I.seeElement('[name="root[3][property]"]');
+//   I.seeElement('[name="root[4][property]"]');
+//   I.fillField('[name="root[0][property]"]', "1");
+//   I.fillField('[name="root[1][property]"]', "2");
+//   I.fillField('[name="root[2][property]"]', "3");
+//   I.fillField('[name="root[3][property]"]', "4");
+//   I.fillField('[name="root[4][property]"]', "5");
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[{"property":"1"},{"property":"2"},{"property":"3"},{"property":"4"},{"property":"5"}]');
+
+//   // shuffle
+//   I.click('.moveup[data-i="4"]');
+//   I.click('.moveup[data-i="2"]');
+//   I.click('.moveup[data-i="1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[{"property":"3"},{"property":"1"},{"property":"2"},{"property":"5"},{"property":"4"}]');
+
+//   // delete single
+//   I.see('Object 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Object 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Object 5');
+
+//   // delete last
+//   I.see('Object 4');
+//   I.click('Delete Last Object');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Object 4');
+//   I.click('Delete Last Object');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Object 4');
+
+//   // delete all
+//   I.see('Object 1');
+//   I.see('Object 2');
+//   I.see('Object 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Object 1');
+//   I.see('Object 2');
+//   I.see('Object 3');
+//   I.click('Delete All');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Object 1');
+//   I.dontSee('Object 2');
+//   I.dontSee('Object 3');
+// });
+
+// Scenario('should work well with nested array editors', async (I) => {
+//   I.amOnPage('array-nested-arrays.html');
+//   I.click('Add Array');
+//   I.click('Add Array');
+//   I.click('Add Array');
+//   I.click('Add Array');
+//   I.click('Add Array');
+//   I.seeElement('[data-schemapath="root.0"]');
+//   I.seeElement('[data-schemapath="root.1"]');
+//   I.seeElement('[data-schemapath="root.2"]');
+//   I.seeElement('[data-schemapath="root.3"]');
+//   I.seeElement('[data-schemapath="root.4"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[[],[],[],[],[]]');
+
+//   // adds one string editor in each first level array
+//   for (i = 0; i < 5; i++) {
+//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
+//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][0]"]', String(i + 1));
+//   }
+
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
+
+//   // shuffle
+//   I.click('.moveup[data-i="4"]');
+//   I.click('.moveup[data-i="2"]');
+//   I.click('.moveup[data-i="1"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
+
+//   // delete single
+//   I.see('Array 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Array 5');
+//   I.click('[data-schemapath="root.4"] .delete');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Array 5');
+
+//   // delete last
+//   I.see('Array 4');
+//   I.click('Delete Last Array');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Array 4');
+//   I.click('Delete Last Array');
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Array 4');
+
+//   // delete all
+//   I.see('Array 1');
+//   I.see('Array 2');
+//   I.see('Array 3');
+//   // there are hidden "Delete All" buttons right now and "I.click(Delete All)"
+//   // will attempt to click the first match. It fails because is hidden.
+//   // this is why i use this script. is more flexible.
+//   I.executeScript(function() {
+//     var e = document.querySelectorAll('.json-editor-btn-delete');
+//     e[e.length - 1].click();
+//   });
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.cancelPopup();
+//   I.see('Array 1');
+//   I.see('Array 2');
+//   I.see('Array 3');
+//   I.executeScript(function() {
+//     var e = document.querySelectorAll('.json-editor-btn-delete');
+//     e[e.length - 1].click();
+//   });
+//   I.seeInPopup('Are you sure you want to remove this node?');
+//   I.acceptPopup();
+//   I.dontSee('Array 1');
+//   I.dontSee('Array 2');
+//   I.dontSee('Array 3');
+
+//   // manipulate nested items
+//   I.amOnPage('array-nested-arrays.html');
+//   I.click('Add Array');
+//   I.click('Add Array');
+//   I.click('Add Array');
+//   I.click('Add Array');
+//   I.click('Add Array');
+//   I.seeElement('[data-schemapath="root.0"]');
+//   I.seeElement('[data-schemapath="root.1"]');
+//   I.seeElement('[data-schemapath="root.2"]');
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[[],[],[],[],[]]');
+
+//   // adds one string editor in each first level array
+//   for (i = 0; i < 5; i++) {
+//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
+//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
+//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
+//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
+//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
+//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][0]"]', "1");
+//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][1]"]', "2");
+//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][2]"]', "3");
+//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][3]"]', "4");
+//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][4]"]', "5");
+//   }
+
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"]]');
+
+//   // shuffle every strings array
+//   for (i = 0; i < 5; i++) {
+//     I.click('[data-schemapath="root.' + i + '.4"] .moveup');
+//     I.click('[data-schemapath="root.' + i + '.2"] .moveup');
+//     I.click('[data-schemapath="root.' + i + '.1"] .moveup');
+//   }
+
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"]]');
+
+//   // delete single (fifth) element from every string array
+//   for (i = 0; i < 5; i++) {
+//     I.see('String 5', '[data-schemapath="root.' + i + '"]');
+//     I.click('[data-schemapath="root.' + i + '.4"] .delete');
+//     I.seeInPopup('Are you sure you want to remove this node?');
+//     I.cancelPopup();
+//     I.see('String 5', '[data-schemapath="root.' + i + '"]');
+//     I.click('[data-schemapath="root.' + i + '.4"] .delete');
+//     I.seeInPopup('Are you sure you want to remove this node?');
+//     I.acceptPopup();
+//     I.dontSee('String 5', '[data-schemapath="root.' + i + '"]');
+//   }
+
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["3","1","2","5"],["3","1","2","5"],["3","1","2","5"],["3","1","2","5"],["3","1","2","5"]]');
+
+//   // delete last (fourth) element from every string array
+//   for (i = 0; i < 5; i++) {
+//     I.see('String 4', '[data-schemapath="root.' + i + '"]');
+//     I.click('Delete Last String', '[data-schemapath="root.' + i + '"]');
+//     I.seeInPopup('Are you sure you want to remove this node?');
+//     I.cancelPopup();
+//     I.see('String 4', '[data-schemapath="root.' + i + '"]');
+//     I.click('Delete Last String', '[data-schemapath="root.' + i + '"]');
+//     I.seeInPopup('Are you sure you want to remove this node?');
+//     I.acceptPopup();
+//     I.dontSee('String 4', '[data-schemapath="root.' + i + '"]');
+//   }
+
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[["3","1","2"],["3","1","2"],["3","1","2"],["3","1","2"],["3","1","2"]]');
+
+//   // delete last (fourth) element from every string array
+//   for (i = 0; i < 5; i++) {
+//     I.see('String 1', '[data-schemapath="root.' + i + '"]');
+//     I.see('String 2', '[data-schemapath="root.' + i + '"]');
+//     I.see('String 3', '[data-schemapath="root.' + i + '"]');
+//     I.click('Delete All', '[data-schemapath="root.' + i + '"]');
+//     I.seeInPopup('Are you sure you want to remove this node?');
+//     I.cancelPopup();
+//     I.see('String 1', '[data-schemapath="root.' + i + '"]');
+//     I.see('String 2', '[data-schemapath="root.' + i + '"]');
+//     I.see('String 3', '[data-schemapath="root.' + i + '"]');
+//     I.click('Delete All', '[data-schemapath="root.' + i + '"]');
+//     I.seeInPopup('Are you sure you want to remove this node?');
+//     I.acceptPopup();
+//     I.dontSee('String 1', '[data-schemapath="root.' + i + '"]');
+//     I.dontSee('String 2', '[data-schemapath="root.' + i + '"]');
+//     I.dontSee('String 3', '[data-schemapath="root.' + i + '"]');
+//   }
+
+//   I.click('.get-value');
+//   value = await I.grabValueFrom('.debug');
+//   assert.equal(value, '[[],[],[],[],[]]');
+
+// });
 
 Scenario('should work well with selectize multiselect editors', async (I) => {
   I.amOnPage('array-selectize.html');
@@ -785,19 +785,20 @@ Scenario('should work well with selectize multiselect editors', async (I) => {
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
   // ensure defaults
-  assert.equal(value, '[["1","2","3","4"],["1","2","3","4"]]');
+  assert.equal(value, '[["1","2"],["1","2"]]');
 
   // every selected item has remove button
   I.seeElement('[data-schemapath="root.0"] .selectize-input [data-value="1"] a.remove');
   I.seeElement('[data-schemapath="root.0"] .selectize-input [data-value="2"] a.remove');
-  I.seeElement('[data-schemapath="root.0"] .selectize-input [data-value="3"] a.remove');
-  I.seeElement('[data-schemapath="root.0"] .selectize-input [data-value="4"] a.remove');
   I.seeElement('[data-schemapath="root.1"] .selectize-input [data-value="1"] a.remove');
   I.seeElement('[data-schemapath="root.1"] .selectize-input [data-value="2"] a.remove');
-  I.seeElement('[data-schemapath="root.1"] .selectize-input [data-value="3"] a.remove');
-  I.seeElement('[data-schemapath="root.1"] .selectize-input [data-value="4"] a.remove');
 
   // could not add values
   I.fillField('[data-schemapath="root.1"] input[type="text"]', "123");
   I.dontSeeElement('.create.active');
+
+  // selectize dropdown is filled with enum values
+  I.click('[data-schemapath="root.0"] .selectize-input');
+  I.seeElement('[data-schemapath="root.0"] .selectize-dropdown-content [data-value="3"]');
+  I.seeElement('[data-schemapath="root.0"] .selectize-dropdown-content [data-value="4"]');
 });

--- a/tests/codeceptjs/editors/array_test.js
+++ b/tests/codeceptjs/editors/array_test.js
@@ -3,778 +3,778 @@ var i;
 
 Feature('array');
 
-// Scenario('should have correct initial value', async (I) => {
-//   I.amOnPage('array.html');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[]');
-// });
-
-// Scenario('should array editing triggers', async (I) => {
-//   I.amOnPage('array-move-events.html');
-//   I.seeElement('[data-schemapath="root.0"]');
-//   I.seeElement('[data-schemapath="root.1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '["A","B"]');
-
-//   I.click('.json-editor-btn-moveup');
-//   I.seeInPopup('moveRow');
-//   I.acceptPopup();
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '["B","A"]');
-
-//   I.click('.json-editor-btn-movedown');
-//   I.seeInPopup('moveRow');
-//   I.acceptPopup();
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '["A","B"]');
-
-//   I.click('.json-editor-btntype-add');
-//   I.seeInPopup('addRow');
-//   I.acceptPopup();
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '["A","B",""]');
-
-//   I.click('.json-editor-btntype-deletelast');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.seeInPopup('deleteRow');
-//   I.acceptPopup();
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '["A","B"]');
-
-//   I.click('.json-editor-btntype-deleteall');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.seeInPopup('deleteAllRows');
-//   I.acceptPopup();
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[]');
-// });
-
-// Scenario('should work well with string editors', async (I) => {
-//   I.amOnPage('array-strings.html');
-//   I.click('Add String');
-//   I.click('Add String');
-//   I.click('Add String');
-//   I.click('Add String');
-//   I.click('Add String');
-//   I.seeElement('[name="root[0]"]');
-//   I.seeElement('[name="root[1]"]');
-//   I.seeElement('[name="root[2]"]');
-//   I.seeElement('[name="root[3]"]');
-//   I.seeElement('[name="root[4]"]');
-//   I.fillField('[name="root[0]"]', "1");
-//   I.fillField('[name="root[1]"]', "2");
-//   I.fillField('[name="root[2]"]', "3");
-//   I.fillField('[name="root[3]"]', "4");
-//   I.fillField('[name="root[4]"]', "5");
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '["1","2","3","4","5"]');
-
-//   // shuffle
-//   I.click('.moveup[data-i="4"]');
-//   I.click('.moveup[data-i="2"]');
-//   I.click('.moveup[data-i="1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '["3","1","2","5","4"]');
-
-//   // delete single
-//   I.see('String 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('String 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('String 5');
-
-//   // delete last
-//   I.see('String 4');
-//   I.click('Delete Last String');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('String 4');
-//   I.click('Delete Last String');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('String 4');
-
-//   // delete all
-//   I.see('String 1');
-//   I.see('String 2');
-//   I.see('String 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('String 1');
-//   I.see('String 2');
-//   I.see('String 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('String 1');
-//   I.dontSee('String 2');
-//   I.dontSee('String 3');
-// });
-
-// Scenario('should work well with number editors', async (I) => {
-//   I.amOnPage('array-numbers.html');
-//   I.click('Add Number');
-//   I.click('Add Number');
-//   I.click('Add Number');
-//   I.click('Add Number');
-//   I.click('Add Number');
-//   I.seeElement('[name="root[0]"]');
-//   I.seeElement('[name="root[1]"]');
-//   I.seeElement('[name="root[2]"]');
-//   I.seeElement('[name="root[3]"]');
-//   I.seeElement('[name="root[4]"]');
-//   I.fillField('[name="root[0]"]', "1");
-//   I.fillField('[name="root[1]"]', "2");
-//   I.fillField('[name="root[2]"]', "3");
-//   I.fillField('[name="root[3]"]', "4");
-//   I.fillField('[name="root[4]"]', "5");
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[1,2,3,4,5]');
-
-//   // shuffle
-//   I.click('.moveup[data-i="4"]');
-//   I.click('.moveup[data-i="2"]');
-//   I.click('.moveup[data-i="1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[3,1,2,5,4]');
-
-//   // delete single
-//   I.see('Number 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Number 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Number 5');
-
-//   // delete last
-//   I.see('Number 4');
-//   I.click('Delete Last Number');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Number 4');
-//   I.click('Delete Last Number');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Number 4');
-
-//   // delete all
-//   I.see('Number 1');
-//   I.see('Number 2');
-//   I.see('Number 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Number 1');
-//   I.see('Number 2');
-//   I.see('Number 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Number 1');
-//   I.dontSee('Number 2');
-//   I.dontSee('Number 3');
-// });
-
-// Scenario('should work well with integer editors', async (I) => {
-//   I.amOnPage('array-integers.html');
-//   I.click('Add Integer');
-//   I.click('Add Integer');
-//   I.click('Add Integer');
-//   I.click('Add Integer');
-//   I.click('Add Integer');
-//   I.seeElement('[name="root[0]"]');
-//   I.seeElement('[name="root[1]"]');
-//   I.seeElement('[name="root[2]"]');
-//   I.seeElement('[name="root[3]"]');
-//   I.seeElement('[name="root[4]"]');
-//   I.fillField('[name="root[0]"]', "1");
-//   I.fillField('[name="root[1]"]', "2");
-//   I.fillField('[name="root[2]"]', "3");
-//   I.fillField('[name="root[3]"]', "4");
-//   I.fillField('[name="root[4]"]', "5");
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[1,2,3,4,5]');
-
-//   // shuffle
-//   I.click('.moveup[data-i="4"]');
-//   I.click('.moveup[data-i="2"]');
-//   I.click('.moveup[data-i="1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[3,1,2,5,4]');
-
-//   // delete single
-//   I.see('Integer 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Integer 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Integer 5');
-
-//   // delete last
-//   I.see('Integer 4');
-//   I.click('Delete Last Integer');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Integer 4');
-//   I.click('Delete Last Integer');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Integer 4');
-
-//   // delete all
-//   I.see('Integer 1');
-//   I.see('Integer 2');
-//   I.see('Integer 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Integer 1');
-//   I.see('Integer 2');
-//   I.see('Integer 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Integer 1');
-//   I.dontSee('Integer 2');
-//   I.dontSee('Integer 3');
-// });
-
-// Scenario('should work well with select editors', async (I) => {
-//   I.amOnPage('array-selects.html');
-//   I.click('Add Select');
-//   I.click('Add Select');
-//   I.seeElement('[name="root[0]"]');
-//   I.seeElement('[name="root[1]"]');
-//   I.selectOption('[name="root[0]"]', "true");
-//   I.selectOption('[name="root[1]"]', "false");
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[true,false]');
-
-//   // shuffle
-//   I.click('.moveup[data-i="1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[false,true]');
-
-//   // delete single
-//   I.click('Add Select');
-//   I.click('Add Select');
-//   I.click('Add Select');
-//   I.see('Select 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Select 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Select 5');
-
-//   // delete last
-//   I.see('Select 4');
-//   I.click('Delete Last Select');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Select 4');
-//   I.click('Delete Last Select');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Select 4');
-
-//   // delete all
-//   I.see('Select 1');
-//   I.see('Select 2');
-//   I.see('Select 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Select 1');
-//   I.see('Select 2');
-//   I.see('Select 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Select 1');
-//   I.dontSee('Select 2');
-//   I.dontSee('Select 3');
-// });
-
-// Scenario('should work well with checkbox editors', async (I) => {
-//   I.amOnPage('array-checkboxes.html');
-//   I.click('Add Checkbox');
-//   I.click('Add Checkbox');
-//   I.click('Add Checkbox');
-//   I.click('Add Checkbox');
-//   I.click('Add Checkbox');
-//   I.seeElement('[data-schemapath="root.0"]');
-//   I.seeElement('[data-schemapath="root.1"]');
-//   I.seeElement('[data-schemapath="root.2"]');
-//   I.seeElement('[data-schemapath="root.3"]');
-//   I.seeElement('[data-schemapath="root.4"]');
-//   I.checkOption('1', '[data-schemapath="root.0"]');
-//   I.checkOption('2', '[data-schemapath="root.1"]');
-//   I.checkOption('3', '[data-schemapath="root.2"]');
-//   I.checkOption('4', '[data-schemapath="root.3"]');
-//   I.checkOption('5', '[data-schemapath="root.4"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
-
-//   // shuffle
-//   I.click('.moveup[data-i="4"]');
-//   I.click('.moveup[data-i="2"]');
-//   I.click('.moveup[data-i="1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
-
-//   // delete single
-//   I.see('Checkbox 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Checkbox 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Checkbox 5');
-
-//   // delete last
-//   I.see('Checkbox 4');
-//   I.click('Delete Last Checkbox');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Checkbox 4');
-//   I.click('Delete Last Checkbox');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Checkbox 4');
-
-//   // delete all
-//   I.see('Checkbox 1');
-//   I.see('Checkbox 2');
-//   I.see('Checkbox 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Checkbox 1');
-//   I.see('Checkbox 2');
-//   I.see('Checkbox 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Checkbox 1');
-//   I.dontSee('Checkbox 2');
-//   I.dontSee('Checkbox 3');
-// });
-
-// Scenario('should work well with rating editors', async (I) => {
-//   I.amOnPage('array-ratings.html');
-//   I.seeElement('[data-schemapath="root.0"]');
-//   I.seeElement('[data-schemapath="root.1"]');
-//   I.seeElement('[data-schemapath="root.2"]');
-//   I.seeElement('[data-schemapath="root.3"]');
-//   I.seeElement('[data-schemapath="root.4"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[1,2,3,4,5]');
-
-//   // shuffle
-//   I.click('.moveup[data-i="4"]');
-//   I.click('.moveup[data-i="2"]');
-//   I.click('.moveup[data-i="1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[3,1,2,5,4]');
-
-//   // delete single
-//   I.see('Rating 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Rating 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Rating 5');
-
-//   // delete last
-//   I.see('Rating 4');
-//   I.click('Delete Last Rating');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Rating 4');
-//   I.click('Delete Last Rating');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Rating 4');
-
-//   // delete all
-//   I.see('Rating 1');
-//   I.see('Rating 2');
-//   I.see('Rating 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Rating 1');
-//   I.see('Rating 2');
-//   I.see('Rating 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Rating 1');
-//   I.dontSee('Rating 2');
-//   I.dontSee('Rating 3');
-// });
-
-// Scenario('should work well with multiselect editors', async (I) => {
-//   I.amOnPage('array-multiselects.html');
-//   I.click('Add Multiselect');
-//   I.click('Add Multiselect');
-//   I.click('Add Multiselect');
-//   I.click('Add Multiselect');
-//   I.click('Add Multiselect');
-//   I.seeElement('[data-schemapath="root.0"]');
-//   I.seeElement('[data-schemapath="root.1"]');
-//   I.seeElement('[data-schemapath="root.2"]');
-//   I.seeElement('[data-schemapath="root.3"]');
-//   I.seeElement('[data-schemapath="root.4"]');
-//   I.selectOption('[name="root[0]"]', "1");
-//   I.selectOption('[name="root[1]"]', "2");
-//   I.selectOption('[name="root[2]"]', "3");
-//   I.selectOption('[name="root[3]"]', "4");
-//   I.selectOption('[name="root[4]"]', "5");
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
-
-//   // shuffle
-//   I.click('.moveup[data-i="4"]');
-//   I.click('.moveup[data-i="2"]');
-//   I.click('.moveup[data-i="1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
-
-//   // delete single
-//   I.see('Multiselect 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Multiselect 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Multiselect 5');
-
-//   // delete last
-//   I.see('Multiselect 4');
-//   I.click('Delete Last Multiselect');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Multiselect 4');
-//   I.click('Delete Last Multiselect');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Multiselect 4');
-
-//   // delete all
-//   I.see('Multiselect 1');
-//   I.see('Multiselect 2');
-//   I.see('Multiselect 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Multiselect 1');
-//   I.see('Multiselect 2');
-//   I.see('Multiselect 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Multiselect 1');
-//   I.dontSee('Multiselect 2');
-//   I.dontSee('Multiselect 3');
-// });
-
-// Scenario('should work well with object editors', async (I) => {
-//   I.amOnPage('array-objects.html');
-//   I.click('Add Object');
-//   I.click('Add Object');
-//   I.click('Add Object');
-//   I.click('Add Object');
-//   I.click('Add Object');
-//   I.seeElement('[name="root[0][property]"]');
-//   I.seeElement('[name="root[1][property]"]');
-//   I.seeElement('[name="root[2][property]"]');
-//   I.seeElement('[name="root[3][property]"]');
-//   I.seeElement('[name="root[4][property]"]');
-//   I.fillField('[name="root[0][property]"]', "1");
-//   I.fillField('[name="root[1][property]"]', "2");
-//   I.fillField('[name="root[2][property]"]', "3");
-//   I.fillField('[name="root[3][property]"]', "4");
-//   I.fillField('[name="root[4][property]"]', "5");
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[{"property":"1"},{"property":"2"},{"property":"3"},{"property":"4"},{"property":"5"}]');
-
-//   // shuffle
-//   I.click('.moveup[data-i="4"]');
-//   I.click('.moveup[data-i="2"]');
-//   I.click('.moveup[data-i="1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[{"property":"3"},{"property":"1"},{"property":"2"},{"property":"5"},{"property":"4"}]');
-
-//   // delete single
-//   I.see('Object 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Object 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Object 5');
-
-//   // delete last
-//   I.see('Object 4');
-//   I.click('Delete Last Object');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Object 4');
-//   I.click('Delete Last Object');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Object 4');
-
-//   // delete all
-//   I.see('Object 1');
-//   I.see('Object 2');
-//   I.see('Object 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Object 1');
-//   I.see('Object 2');
-//   I.see('Object 3');
-//   I.click('Delete All');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Object 1');
-//   I.dontSee('Object 2');
-//   I.dontSee('Object 3');
-// });
-
-// Scenario('should work well with nested array editors', async (I) => {
-//   I.amOnPage('array-nested-arrays.html');
-//   I.click('Add Array');
-//   I.click('Add Array');
-//   I.click('Add Array');
-//   I.click('Add Array');
-//   I.click('Add Array');
-//   I.seeElement('[data-schemapath="root.0"]');
-//   I.seeElement('[data-schemapath="root.1"]');
-//   I.seeElement('[data-schemapath="root.2"]');
-//   I.seeElement('[data-schemapath="root.3"]');
-//   I.seeElement('[data-schemapath="root.4"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[[],[],[],[],[]]');
-
-//   // adds one string editor in each first level array
-//   for (i = 0; i < 5; i++) {
-//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
-//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][0]"]', String(i + 1));
-//   }
-
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
-
-//   // shuffle
-//   I.click('.moveup[data-i="4"]');
-//   I.click('.moveup[data-i="2"]');
-//   I.click('.moveup[data-i="1"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
-
-//   // delete single
-//   I.see('Array 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Array 5');
-//   I.click('[data-schemapath="root.4"] .delete');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Array 5');
-
-//   // delete last
-//   I.see('Array 4');
-//   I.click('Delete Last Array');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Array 4');
-//   I.click('Delete Last Array');
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Array 4');
-
-//   // delete all
-//   I.see('Array 1');
-//   I.see('Array 2');
-//   I.see('Array 3');
-//   // there are hidden "Delete All" buttons right now and "I.click(Delete All)"
-//   // will attempt to click the first match. It fails because is hidden.
-//   // this is why i use this script. is more flexible.
-//   I.executeScript(function() {
-//     var e = document.querySelectorAll('.json-editor-btn-delete');
-//     e[e.length - 1].click();
-//   });
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.cancelPopup();
-//   I.see('Array 1');
-//   I.see('Array 2');
-//   I.see('Array 3');
-//   I.executeScript(function() {
-//     var e = document.querySelectorAll('.json-editor-btn-delete');
-//     e[e.length - 1].click();
-//   });
-//   I.seeInPopup('Are you sure you want to remove this node?');
-//   I.acceptPopup();
-//   I.dontSee('Array 1');
-//   I.dontSee('Array 2');
-//   I.dontSee('Array 3');
-
-//   // manipulate nested items
-//   I.amOnPage('array-nested-arrays.html');
-//   I.click('Add Array');
-//   I.click('Add Array');
-//   I.click('Add Array');
-//   I.click('Add Array');
-//   I.click('Add Array');
-//   I.seeElement('[data-schemapath="root.0"]');
-//   I.seeElement('[data-schemapath="root.1"]');
-//   I.seeElement('[data-schemapath="root.2"]');
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[[],[],[],[],[]]');
-
-//   // adds one string editor in each first level array
-//   for (i = 0; i < 5; i++) {
-//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
-//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
-//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
-//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
-//     I.click('Add String', '[data-schemapath="root.' + i + '"]');
-//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][0]"]', "1");
-//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][1]"]', "2");
-//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][2]"]', "3");
-//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][3]"]', "4");
-//     I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][4]"]', "5");
-//   }
-
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"]]');
-
-//   // shuffle every strings array
-//   for (i = 0; i < 5; i++) {
-//     I.click('[data-schemapath="root.' + i + '.4"] .moveup');
-//     I.click('[data-schemapath="root.' + i + '.2"] .moveup');
-//     I.click('[data-schemapath="root.' + i + '.1"] .moveup');
-//   }
-
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"]]');
-
-//   // delete single (fifth) element from every string array
-//   for (i = 0; i < 5; i++) {
-//     I.see('String 5', '[data-schemapath="root.' + i + '"]');
-//     I.click('[data-schemapath="root.' + i + '.4"] .delete');
-//     I.seeInPopup('Are you sure you want to remove this node?');
-//     I.cancelPopup();
-//     I.see('String 5', '[data-schemapath="root.' + i + '"]');
-//     I.click('[data-schemapath="root.' + i + '.4"] .delete');
-//     I.seeInPopup('Are you sure you want to remove this node?');
-//     I.acceptPopup();
-//     I.dontSee('String 5', '[data-schemapath="root.' + i + '"]');
-//   }
-
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["3","1","2","5"],["3","1","2","5"],["3","1","2","5"],["3","1","2","5"],["3","1","2","5"]]');
-
-//   // delete last (fourth) element from every string array
-//   for (i = 0; i < 5; i++) {
-//     I.see('String 4', '[data-schemapath="root.' + i + '"]');
-//     I.click('Delete Last String', '[data-schemapath="root.' + i + '"]');
-//     I.seeInPopup('Are you sure you want to remove this node?');
-//     I.cancelPopup();
-//     I.see('String 4', '[data-schemapath="root.' + i + '"]');
-//     I.click('Delete Last String', '[data-schemapath="root.' + i + '"]');
-//     I.seeInPopup('Are you sure you want to remove this node?');
-//     I.acceptPopup();
-//     I.dontSee('String 4', '[data-schemapath="root.' + i + '"]');
-//   }
-
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[["3","1","2"],["3","1","2"],["3","1","2"],["3","1","2"],["3","1","2"]]');
-
-//   // delete last (fourth) element from every string array
-//   for (i = 0; i < 5; i++) {
-//     I.see('String 1', '[data-schemapath="root.' + i + '"]');
-//     I.see('String 2', '[data-schemapath="root.' + i + '"]');
-//     I.see('String 3', '[data-schemapath="root.' + i + '"]');
-//     I.click('Delete All', '[data-schemapath="root.' + i + '"]');
-//     I.seeInPopup('Are you sure you want to remove this node?');
-//     I.cancelPopup();
-//     I.see('String 1', '[data-schemapath="root.' + i + '"]');
-//     I.see('String 2', '[data-schemapath="root.' + i + '"]');
-//     I.see('String 3', '[data-schemapath="root.' + i + '"]');
-//     I.click('Delete All', '[data-schemapath="root.' + i + '"]');
-//     I.seeInPopup('Are you sure you want to remove this node?');
-//     I.acceptPopup();
-//     I.dontSee('String 1', '[data-schemapath="root.' + i + '"]');
-//     I.dontSee('String 2', '[data-schemapath="root.' + i + '"]');
-//     I.dontSee('String 3', '[data-schemapath="root.' + i + '"]');
-//   }
-
-//   I.click('.get-value');
-//   value = await I.grabValueFrom('.debug');
-//   assert.equal(value, '[[],[],[],[],[]]');
-
-// });
+Scenario('should have correct initial value', async (I) => {
+  I.amOnPage('array.html');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[]');
+});
+
+Scenario('should array editing triggers', async (I) => {
+  I.amOnPage('array-move-events.html');
+  I.seeElement('[data-schemapath="root.0"]');
+  I.seeElement('[data-schemapath="root.1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '["A","B"]');
+
+  I.click('.json-editor-btn-moveup');
+  I.seeInPopup('moveRow');
+  I.acceptPopup();
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '["B","A"]');
+
+  I.click('.json-editor-btn-movedown');
+  I.seeInPopup('moveRow');
+  I.acceptPopup();
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '["A","B"]');
+
+  I.click('.json-editor-btntype-add');
+  I.seeInPopup('addRow');
+  I.acceptPopup();
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '["A","B",""]');
+
+  I.click('.json-editor-btntype-deletelast');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.seeInPopup('deleteRow');
+  I.acceptPopup();
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '["A","B"]');
+
+  I.click('.json-editor-btntype-deleteall');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.seeInPopup('deleteAllRows');
+  I.acceptPopup();
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[]');
+});
+
+Scenario('should work well with string editors', async (I) => {
+  I.amOnPage('array-strings.html');
+  I.click('Add String');
+  I.click('Add String');
+  I.click('Add String');
+  I.click('Add String');
+  I.click('Add String');
+  I.seeElement('[name="root[0]"]');
+  I.seeElement('[name="root[1]"]');
+  I.seeElement('[name="root[2]"]');
+  I.seeElement('[name="root[3]"]');
+  I.seeElement('[name="root[4]"]');
+  I.fillField('[name="root[0]"]', "1");
+  I.fillField('[name="root[1]"]', "2");
+  I.fillField('[name="root[2]"]', "3");
+  I.fillField('[name="root[3]"]', "4");
+  I.fillField('[name="root[4]"]', "5");
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '["1","2","3","4","5"]');
+
+  // shuffle
+  I.click('.moveup[data-i="4"]');
+  I.click('.moveup[data-i="2"]');
+  I.click('.moveup[data-i="1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '["3","1","2","5","4"]');
+
+  // delete single
+  I.see('String 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('String 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('String 5');
+
+  // delete last
+  I.see('String 4');
+  I.click('Delete Last String');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('String 4');
+  I.click('Delete Last String');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('String 4');
+
+  // delete all
+  I.see('String 1');
+  I.see('String 2');
+  I.see('String 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('String 1');
+  I.see('String 2');
+  I.see('String 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('String 1');
+  I.dontSee('String 2');
+  I.dontSee('String 3');
+});
+
+Scenario('should work well with number editors', async (I) => {
+  I.amOnPage('array-numbers.html');
+  I.click('Add Number');
+  I.click('Add Number');
+  I.click('Add Number');
+  I.click('Add Number');
+  I.click('Add Number');
+  I.seeElement('[name="root[0]"]');
+  I.seeElement('[name="root[1]"]');
+  I.seeElement('[name="root[2]"]');
+  I.seeElement('[name="root[3]"]');
+  I.seeElement('[name="root[4]"]');
+  I.fillField('[name="root[0]"]', "1");
+  I.fillField('[name="root[1]"]', "2");
+  I.fillField('[name="root[2]"]', "3");
+  I.fillField('[name="root[3]"]', "4");
+  I.fillField('[name="root[4]"]', "5");
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[1,2,3,4,5]');
+
+  // shuffle
+  I.click('.moveup[data-i="4"]');
+  I.click('.moveup[data-i="2"]');
+  I.click('.moveup[data-i="1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[3,1,2,5,4]');
+
+  // delete single
+  I.see('Number 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Number 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Number 5');
+
+  // delete last
+  I.see('Number 4');
+  I.click('Delete Last Number');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Number 4');
+  I.click('Delete Last Number');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Number 4');
+
+  // delete all
+  I.see('Number 1');
+  I.see('Number 2');
+  I.see('Number 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Number 1');
+  I.see('Number 2');
+  I.see('Number 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Number 1');
+  I.dontSee('Number 2');
+  I.dontSee('Number 3');
+});
+
+Scenario('should work well with integer editors', async (I) => {
+  I.amOnPage('array-integers.html');
+  I.click('Add Integer');
+  I.click('Add Integer');
+  I.click('Add Integer');
+  I.click('Add Integer');
+  I.click('Add Integer');
+  I.seeElement('[name="root[0]"]');
+  I.seeElement('[name="root[1]"]');
+  I.seeElement('[name="root[2]"]');
+  I.seeElement('[name="root[3]"]');
+  I.seeElement('[name="root[4]"]');
+  I.fillField('[name="root[0]"]', "1");
+  I.fillField('[name="root[1]"]', "2");
+  I.fillField('[name="root[2]"]', "3");
+  I.fillField('[name="root[3]"]', "4");
+  I.fillField('[name="root[4]"]', "5");
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[1,2,3,4,5]');
+
+  // shuffle
+  I.click('.moveup[data-i="4"]');
+  I.click('.moveup[data-i="2"]');
+  I.click('.moveup[data-i="1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[3,1,2,5,4]');
+
+  // delete single
+  I.see('Integer 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Integer 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Integer 5');
+
+  // delete last
+  I.see('Integer 4');
+  I.click('Delete Last Integer');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Integer 4');
+  I.click('Delete Last Integer');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Integer 4');
+
+  // delete all
+  I.see('Integer 1');
+  I.see('Integer 2');
+  I.see('Integer 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Integer 1');
+  I.see('Integer 2');
+  I.see('Integer 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Integer 1');
+  I.dontSee('Integer 2');
+  I.dontSee('Integer 3');
+});
+
+Scenario('should work well with select editors', async (I) => {
+  I.amOnPage('array-selects.html');
+  I.click('Add Select');
+  I.click('Add Select');
+  I.seeElement('[name="root[0]"]');
+  I.seeElement('[name="root[1]"]');
+  I.selectOption('[name="root[0]"]', "true");
+  I.selectOption('[name="root[1]"]', "false");
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[true,false]');
+
+  // shuffle
+  I.click('.moveup[data-i="1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[false,true]');
+
+  // delete single
+  I.click('Add Select');
+  I.click('Add Select');
+  I.click('Add Select');
+  I.see('Select 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Select 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Select 5');
+
+  // delete last
+  I.see('Select 4');
+  I.click('Delete Last Select');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Select 4');
+  I.click('Delete Last Select');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Select 4');
+
+  // delete all
+  I.see('Select 1');
+  I.see('Select 2');
+  I.see('Select 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Select 1');
+  I.see('Select 2');
+  I.see('Select 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Select 1');
+  I.dontSee('Select 2');
+  I.dontSee('Select 3');
+});
+
+Scenario('should work well with checkbox editors', async (I) => {
+  I.amOnPage('array-checkboxes.html');
+  I.click('Add Checkbox');
+  I.click('Add Checkbox');
+  I.click('Add Checkbox');
+  I.click('Add Checkbox');
+  I.click('Add Checkbox');
+  I.seeElement('[data-schemapath="root.0"]');
+  I.seeElement('[data-schemapath="root.1"]');
+  I.seeElement('[data-schemapath="root.2"]');
+  I.seeElement('[data-schemapath="root.3"]');
+  I.seeElement('[data-schemapath="root.4"]');
+  I.checkOption('1', '[data-schemapath="root.0"]');
+  I.checkOption('2', '[data-schemapath="root.1"]');
+  I.checkOption('3', '[data-schemapath="root.2"]');
+  I.checkOption('4', '[data-schemapath="root.3"]');
+  I.checkOption('5', '[data-schemapath="root.4"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
+
+  // shuffle
+  I.click('.moveup[data-i="4"]');
+  I.click('.moveup[data-i="2"]');
+  I.click('.moveup[data-i="1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
+
+  // delete single
+  I.see('Checkbox 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Checkbox 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Checkbox 5');
+
+  // delete last
+  I.see('Checkbox 4');
+  I.click('Delete Last Checkbox');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Checkbox 4');
+  I.click('Delete Last Checkbox');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Checkbox 4');
+
+  // delete all
+  I.see('Checkbox 1');
+  I.see('Checkbox 2');
+  I.see('Checkbox 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Checkbox 1');
+  I.see('Checkbox 2');
+  I.see('Checkbox 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Checkbox 1');
+  I.dontSee('Checkbox 2');
+  I.dontSee('Checkbox 3');
+});
+
+Scenario('should work well with rating editors', async (I) => {
+  I.amOnPage('array-ratings.html');
+  I.seeElement('[data-schemapath="root.0"]');
+  I.seeElement('[data-schemapath="root.1"]');
+  I.seeElement('[data-schemapath="root.2"]');
+  I.seeElement('[data-schemapath="root.3"]');
+  I.seeElement('[data-schemapath="root.4"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[1,2,3,4,5]');
+
+  // shuffle
+  I.click('.moveup[data-i="4"]');
+  I.click('.moveup[data-i="2"]');
+  I.click('.moveup[data-i="1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[3,1,2,5,4]');
+
+  // delete single
+  I.see('Rating 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Rating 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Rating 5');
+
+  // delete last
+  I.see('Rating 4');
+  I.click('Delete Last Rating');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Rating 4');
+  I.click('Delete Last Rating');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Rating 4');
+
+  // delete all
+  I.see('Rating 1');
+  I.see('Rating 2');
+  I.see('Rating 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Rating 1');
+  I.see('Rating 2');
+  I.see('Rating 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Rating 1');
+  I.dontSee('Rating 2');
+  I.dontSee('Rating 3');
+});
+
+Scenario('should work well with multiselect editors', async (I) => {
+  I.amOnPage('array-multiselects.html');
+  I.click('Add Multiselect');
+  I.click('Add Multiselect');
+  I.click('Add Multiselect');
+  I.click('Add Multiselect');
+  I.click('Add Multiselect');
+  I.seeElement('[data-schemapath="root.0"]');
+  I.seeElement('[data-schemapath="root.1"]');
+  I.seeElement('[data-schemapath="root.2"]');
+  I.seeElement('[data-schemapath="root.3"]');
+  I.seeElement('[data-schemapath="root.4"]');
+  I.selectOption('[name="root[0]"]', "1");
+  I.selectOption('[name="root[1]"]', "2");
+  I.selectOption('[name="root[2]"]', "3");
+  I.selectOption('[name="root[3]"]', "4");
+  I.selectOption('[name="root[4]"]', "5");
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
+
+  // shuffle
+  I.click('.moveup[data-i="4"]');
+  I.click('.moveup[data-i="2"]');
+  I.click('.moveup[data-i="1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
+
+  // delete single
+  I.see('Multiselect 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Multiselect 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Multiselect 5');
+
+  // delete last
+  I.see('Multiselect 4');
+  I.click('Delete Last Multiselect');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Multiselect 4');
+  I.click('Delete Last Multiselect');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Multiselect 4');
+
+  // delete all
+  I.see('Multiselect 1');
+  I.see('Multiselect 2');
+  I.see('Multiselect 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Multiselect 1');
+  I.see('Multiselect 2');
+  I.see('Multiselect 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Multiselect 1');
+  I.dontSee('Multiselect 2');
+  I.dontSee('Multiselect 3');
+});
+
+Scenario('should work well with object editors', async (I) => {
+  I.amOnPage('array-objects.html');
+  I.click('Add Object');
+  I.click('Add Object');
+  I.click('Add Object');
+  I.click('Add Object');
+  I.click('Add Object');
+  I.seeElement('[name="root[0][property]"]');
+  I.seeElement('[name="root[1][property]"]');
+  I.seeElement('[name="root[2][property]"]');
+  I.seeElement('[name="root[3][property]"]');
+  I.seeElement('[name="root[4][property]"]');
+  I.fillField('[name="root[0][property]"]', "1");
+  I.fillField('[name="root[1][property]"]', "2");
+  I.fillField('[name="root[2][property]"]', "3");
+  I.fillField('[name="root[3][property]"]', "4");
+  I.fillField('[name="root[4][property]"]', "5");
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[{"property":"1"},{"property":"2"},{"property":"3"},{"property":"4"},{"property":"5"}]');
+
+  // shuffle
+  I.click('.moveup[data-i="4"]');
+  I.click('.moveup[data-i="2"]');
+  I.click('.moveup[data-i="1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[{"property":"3"},{"property":"1"},{"property":"2"},{"property":"5"},{"property":"4"}]');
+
+  // delete single
+  I.see('Object 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Object 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Object 5');
+
+  // delete last
+  I.see('Object 4');
+  I.click('Delete Last Object');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Object 4');
+  I.click('Delete Last Object');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Object 4');
+
+  // delete all
+  I.see('Object 1');
+  I.see('Object 2');
+  I.see('Object 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Object 1');
+  I.see('Object 2');
+  I.see('Object 3');
+  I.click('Delete All');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Object 1');
+  I.dontSee('Object 2');
+  I.dontSee('Object 3');
+});
+
+Scenario('should work well with nested array editors', async (I) => {
+  I.amOnPage('array-nested-arrays.html');
+  I.click('Add Array');
+  I.click('Add Array');
+  I.click('Add Array');
+  I.click('Add Array');
+  I.click('Add Array');
+  I.seeElement('[data-schemapath="root.0"]');
+  I.seeElement('[data-schemapath="root.1"]');
+  I.seeElement('[data-schemapath="root.2"]');
+  I.seeElement('[data-schemapath="root.3"]');
+  I.seeElement('[data-schemapath="root.4"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[[],[],[],[],[]]');
+
+  // adds one string editor in each first level array
+  for (i = 0; i < 5; i++) {
+    I.click('Add String', '[data-schemapath="root.' + i + '"]');
+    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][0]"]', String(i + 1));
+  }
+
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["1"],["2"],["3"],["4"],["5"]]');
+
+  // shuffle
+  I.click('.moveup[data-i="4"]');
+  I.click('.moveup[data-i="2"]');
+  I.click('.moveup[data-i="1"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["3"],["1"],["2"],["5"],["4"]]');
+
+  // delete single
+  I.see('Array 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Array 5');
+  I.click('[data-schemapath="root.4"] .delete');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Array 5');
+
+  // delete last
+  I.see('Array 4');
+  I.click('Delete Last Array');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Array 4');
+  I.click('Delete Last Array');
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Array 4');
+
+  // delete all
+  I.see('Array 1');
+  I.see('Array 2');
+  I.see('Array 3');
+  // there are hidden "Delete All" buttons right now and "I.click(Delete All)"
+  // will attempt to click the first match. It fails because is hidden.
+  // this is why i use this script. is more flexible.
+  I.executeScript(function() {
+    var e = document.querySelectorAll('.json-editor-btn-delete');
+    e[e.length - 1].click();
+  });
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.cancelPopup();
+  I.see('Array 1');
+  I.see('Array 2');
+  I.see('Array 3');
+  I.executeScript(function() {
+    var e = document.querySelectorAll('.json-editor-btn-delete');
+    e[e.length - 1].click();
+  });
+  I.seeInPopup('Are you sure you want to remove this node?');
+  I.acceptPopup();
+  I.dontSee('Array 1');
+  I.dontSee('Array 2');
+  I.dontSee('Array 3');
+
+  // manipulate nested items
+  I.amOnPage('array-nested-arrays.html');
+  I.click('Add Array');
+  I.click('Add Array');
+  I.click('Add Array');
+  I.click('Add Array');
+  I.click('Add Array');
+  I.seeElement('[data-schemapath="root.0"]');
+  I.seeElement('[data-schemapath="root.1"]');
+  I.seeElement('[data-schemapath="root.2"]');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[[],[],[],[],[]]');
+
+  // adds one string editor in each first level array
+  for (i = 0; i < 5; i++) {
+    I.click('Add String', '[data-schemapath="root.' + i + '"]');
+    I.click('Add String', '[data-schemapath="root.' + i + '"]');
+    I.click('Add String', '[data-schemapath="root.' + i + '"]');
+    I.click('Add String', '[data-schemapath="root.' + i + '"]');
+    I.click('Add String', '[data-schemapath="root.' + i + '"]');
+    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][0]"]', "1");
+    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][1]"]', "2");
+    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][2]"]', "3");
+    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][3]"]', "4");
+    I.fillField('[data-schemapath="root.' + i + '"] [name="root[' + i + '][4]"]', "5");
+  }
+
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"],["1","2","3","4","5"]]');
+
+  // shuffle every strings array
+  for (i = 0; i < 5; i++) {
+    I.click('[data-schemapath="root.' + i + '.4"] .moveup');
+    I.click('[data-schemapath="root.' + i + '.2"] .moveup');
+    I.click('[data-schemapath="root.' + i + '.1"] .moveup');
+  }
+
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"],["3","1","2","5","4"]]');
+
+  // delete single (fifth) element from every string array
+  for (i = 0; i < 5; i++) {
+    I.see('String 5', '[data-schemapath="root.' + i + '"]');
+    I.click('[data-schemapath="root.' + i + '.4"] .delete');
+    I.seeInPopup('Are you sure you want to remove this node?');
+    I.cancelPopup();
+    I.see('String 5', '[data-schemapath="root.' + i + '"]');
+    I.click('[data-schemapath="root.' + i + '.4"] .delete');
+    I.seeInPopup('Are you sure you want to remove this node?');
+    I.acceptPopup();
+    I.dontSee('String 5', '[data-schemapath="root.' + i + '"]');
+  }
+
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["3","1","2","5"],["3","1","2","5"],["3","1","2","5"],["3","1","2","5"],["3","1","2","5"]]');
+
+  // delete last (fourth) element from every string array
+  for (i = 0; i < 5; i++) {
+    I.see('String 4', '[data-schemapath="root.' + i + '"]');
+    I.click('Delete Last String', '[data-schemapath="root.' + i + '"]');
+    I.seeInPopup('Are you sure you want to remove this node?');
+    I.cancelPopup();
+    I.see('String 4', '[data-schemapath="root.' + i + '"]');
+    I.click('Delete Last String', '[data-schemapath="root.' + i + '"]');
+    I.seeInPopup('Are you sure you want to remove this node?');
+    I.acceptPopup();
+    I.dontSee('String 4', '[data-schemapath="root.' + i + '"]');
+  }
+
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[["3","1","2"],["3","1","2"],["3","1","2"],["3","1","2"],["3","1","2"]]');
+
+  // delete last (fourth) element from every string array
+  for (i = 0; i < 5; i++) {
+    I.see('String 1', '[data-schemapath="root.' + i + '"]');
+    I.see('String 2', '[data-schemapath="root.' + i + '"]');
+    I.see('String 3', '[data-schemapath="root.' + i + '"]');
+    I.click('Delete All', '[data-schemapath="root.' + i + '"]');
+    I.seeInPopup('Are you sure you want to remove this node?');
+    I.cancelPopup();
+    I.see('String 1', '[data-schemapath="root.' + i + '"]');
+    I.see('String 2', '[data-schemapath="root.' + i + '"]');
+    I.see('String 3', '[data-schemapath="root.' + i + '"]');
+    I.click('Delete All', '[data-schemapath="root.' + i + '"]');
+    I.seeInPopup('Are you sure you want to remove this node?');
+    I.acceptPopup();
+    I.dontSee('String 1', '[data-schemapath="root.' + i + '"]');
+    I.dontSee('String 2', '[data-schemapath="root.' + i + '"]');
+    I.dontSee('String 3', '[data-schemapath="root.' + i + '"]');
+  }
+
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '[[],[],[],[],[]]');
+
+});
 
 Scenario('should work well with selectize multiselect editors', async (I) => {
   I.amOnPage('array-selectize.html');

--- a/tests/pages/array-selectize.html
+++ b/tests/pages/array-selectize.html
@@ -22,15 +22,17 @@
     "title": "Selectize Arrays",
     "items": {
       "type": "array",
+      "format":"select",
       "uniqueItems": true,
+      "default": ["1", "2"],
       "items": {
         "type": "string",
+        "enum": ["1", "2", "3", "4"]
       },
-      "default": ["1", "2", "3", "4"],
       "options": {
         "selectize_options": {
             "create": false,
-            "plugins": ["remove_button"]
+            "plugins": ["remove_button"],
           }
       }
     }


### PR DESCRIPTION
Selectized array had not support of enums, also while running `setValue` it clears all known selectized options.
So, refreshing value is now looks like the following:
1) remove all options
2) append enum options, if present
3) append previously selected options
3rd step is here, as `arraySelectize` by default allowes the user to create new values, so this data has not to be lost.
`defaults.js` is altered also, because if `JSONEditor.plugins.selectize.enable` is set to `true` then it is expected to be everywhere and not to fall back into standard browser select.
