### PR TITLE
Allow HTML in header if DOMPurify is loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following are not required, but can improve the style and usability of JSON 
 *  [Signature Pad](https://github.com/szimek/signature_pad) HTML5 canvas based smooth signature drawing
 *  [Cleave.js](https://github.com/nosir/cleave.js) for formatting your **&lt;input/&gt;** content while you are typing
 *  [math.js](http://mathjs.org/) for more accurate floating point math (multipleOf, divisibleBy, etc.)
-*  [DOMPurify](https://github.com/cure53/DOMPurify) DOM-only, super-fast, uber-tolerant XSS sanitizer. (If you want to use HTML format in descriptions.)
+*  [DOMPurify](https://github.com/cure53/DOMPurify) DOM-only, super-fast, uber-tolerant XSS sanitizer. (If you want to use HTML format in titles/headers and descriptions.)
 
 Usage
 --------------

--- a/src/editor.js
+++ b/src/editor.js
@@ -403,18 +403,20 @@ JSONEditor.AbstractEditor = Class.extend({
   },
   updateHeaderText: function() {
     if(this.header) {
+      var header_text = this.getHeaderText();
       // If the header has children, only update the text node's value
       if(this.header.children.length) {
         for(var i=0; i<this.header.childNodes.length; i++) {
           if(this.header.childNodes[i].nodeType===3) {
-            this.header.childNodes[i].nodeValue = this.getHeaderText();
+            this.header.childNodes[i].nodeValue = this.cleanText(header_text);
             break;
           }
         }
       }
       // Otherwise, just update the entire node
       else {
-        this.header.textContent = this.getHeaderText();
+        if (window.DOMPurify) this.header.innerHTML = window.DOMPurify.sanitize(header_text);
+        else this.header.textContent = this.cleanText(header_text);
       }
     }
   },
@@ -422,6 +424,12 @@ JSONEditor.AbstractEditor = Class.extend({
     if(this.header_text) return this.header_text;
     else if(title_only) return this.schema.title;
     else return this.getTitle();
+  },
+  cleanText: function(txt) {
+    // Clean out HTML tags from txt
+    var tmp = document.createElement('div');
+    tmp.innerHTML = txt;
+    return (tmp.textContent || tmp.innerText);
   },
   onWatchedFieldChange: function() {
     var vars;

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -163,7 +163,7 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
         this.item_title = 'item';
       }
     }
-    return this.item_title;
+    return this.cleanText(this.item_title);
   },
   getItemSchema: function(i) {
     if(Array.isArray(this.schema.items)) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -236,7 +236,7 @@ JSONEditor.AbstractTheme = Class.extend({
   getDescription: function(text) {
     var el = document.createElement('p');
     if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
-    else el.textContent = text;
+    else el.textContent = this.cleanText(text);
     return el;
   },
   getCheckboxDescription: function(text) {
@@ -451,5 +451,11 @@ JSONEditor.AbstractTheme = Class.extend({
   },
   getInputGroup: function(input, buttons) {
     return undefined;
+  },
+  cleanText: function(txt) {
+    // Clean out HTML tags from txt
+    var tmp = document.createElement('div');
+    tmp.innerHTML = txt;
+    return (tmp.textContent || tmp.innerText);
   }
 });

--- a/src/themes/bootstrap2.js
+++ b/src/themes/bootstrap2.js
@@ -90,7 +90,7 @@ JSONEditor.defaults.themes.bootstrap2 = JSONEditor.AbstractTheme.extend({
     var el = document.createElement('p');
     el.classList.add('help-inline');
     if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
-    else el.textContent = text;
+    else el.textContent = this.cleanText(text);
     return el;
   },
   getFormControl: function(label, input, description, infoText) {

--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -109,7 +109,7 @@ JSONEditor.defaults.themes.bootstrap3 = JSONEditor.AbstractTheme.extend({
     var el = document.createElement('p');
     el.classList.add('help-block');
     if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
-    else el.textContent = text;
+    else el.textContent = this.cleanText(text);
     return el;
   },
   getHeaderButtonHolder: function() {

--- a/src/themes/bootstrap4.js
+++ b/src/themes/bootstrap4.js
@@ -69,7 +69,7 @@ JSONEditor.defaults.themes.bootstrap4 = JSONEditor.AbstractTheme.extend({
     var el = document.createElement("p");
     el.classList.add('form-text');
     if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
-    else el.textContent = text;
+    else el.textContent = this.cleanText(text);
     return el;
   },
   getHeaderButtonHolder: function() {

--- a/src/themes/foundation.js
+++ b/src/themes/foundation.js
@@ -43,7 +43,7 @@ JSONEditor.defaults.themes.foundation = JSONEditor.AbstractTheme.extend({
   getFormInputDescription: function(text) {
     var el = document.createElement('p');
     if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
-    else el.textContent = text;
+    else el.textContent = this.cleanText(text);
     el.style.marginTop = '-10px';
     el.style.fontStyle = 'italic';
     return el;

--- a/src/themes/jqueryui.js
+++ b/src/themes/jqueryui.js
@@ -46,7 +46,7 @@ JSONEditor.defaults.themes.jqueryui = JSONEditor.AbstractTheme.extend({
     el.style.fontSize = '.8em';
     el.style.fontStyle = 'italic';
     if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
-    else el.textContent = text;
+    else el.textContent = this.cleanText(text);
     return el;
   },
   getButtonHolder: function() {

--- a/src/themes/materialize.js
+++ b/src/themes/materialize.js
@@ -127,7 +127,7 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
       el.classList.add('grey-text');
       el.style.marginTop = '-15px';
       if (window.DOMPurify) el.innerHTML = window.DOMPurify.sanitize(text);
-      else el.textContent = text;
+      else el.textContent = this.cleanText(text);
       return el;
     },
 


### PR DESCRIPTION
Allow HTML tags in headers if DOMPurify is loaded. (Just like my previous PR with HTML in descriptions)
Also If DOMPurify is not loaded, HTML tags will be filtered from header before display.

Test example. https://is.gd/w6RF5K

BTW: With all the recent bugfixes and new features, I think its time to make a new release? 