### PR TITLE
Fix of #382

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -94,7 +94,7 @@ JSONEditor.AbstractEditor = Class.extend({
   },
   checkDependency: function(path, choices) {
     var wrapper = this.container || this.control;
-    if (this.path === path || !wrapper || this.jsoneditor === null) {   
+    if (this.path === path || !wrapper || this.jsoneditor === null) {
       return;
     }
 
@@ -132,7 +132,7 @@ JSONEditor.AbstractEditor = Class.extend({
       this.dependenciesFulfilled = value === choices;
     } else if (typeof choices === 'boolean') {
       if (choices) {
-        this.dependenciesFulfilled = value && value.length > 0;
+        this.dependenciesFulfilled = value || value.length > 0;
       } else {
         this.dependenciesFulfilled = !value || value.length === 0;
       }

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -41,6 +41,11 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
       if(this.add_row_button) this.add_row_button.disabled = false;
       if(this.remove_all_rows_button) this.remove_all_rows_button.disabled = false;
       if(this.delete_last_row_button) this.delete_last_row_button.disabled = false;
+      if(this.copy_button) this.copy_button.disabled = false;
+      if(this.toggle_button) this.toggle_button.disabled = false;
+      if(this.delete_button) this.delete_button.disabled = false;
+      if(this.moveup_button) this.moveup_button.disabled = false;
+      if(this.movedown_button) this.movedown_button.disabled = false;
 
       if(this.rows) {
         for(var i=0; i<this.rows.length; i++) {
@@ -49,6 +54,11 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
           if(this.rows[i].moveup_button) this.rows[i].moveup_button.disabled = false;
           if(this.rows[i].movedown_button) this.rows[i].movedown_button.disabled = false;
           if(this.rows[i].delete_button) this.rows[i].delete_button.disabled = false;
+          if(this.rows[i].copy_button) this.rows[i].copy_button.disabled = false;
+          if(this.rows[i].toggle_button) this.rows[i].toggle_button.disabled = false;
+          if(this.rows[i].delete_button) this.rows[i].delete_button.disabled = false;
+          if(this.rows[i].moveup_button) this.rows[i].moveup_button.disabled = false;
+          if(this.rows[i].movedown_button) this.rows[i].movedown_button.disabled = false;
         }
       }
       this._super();
@@ -59,6 +69,8 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
     if(this.add_row_button) this.add_row_button.disabled = true;
     if(this.remove_all_rows_button) this.remove_all_rows_button.disabled = true;
     if(this.delete_last_row_button) this.delete_last_row_button.disabled = true;
+    if(this.copy_button) this.copy_button.disabled = true;
+    if(this.toggle_button) this.toggle_button.disabled = true;
 
     if(this.rows) {
       for(var i=0; i<this.rows.length; i++) {
@@ -67,6 +79,8 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
         if(this.rows[i].moveup_button) this.rows[i].moveup_button.disabled = true;
         if(this.rows[i].movedown_button) this.rows[i].movedown_button.disabled = true;
         if(this.rows[i].delete_button) this.rows[i].delete_button.disabled = true;
+        if(this.rows[i].copy_button) this.rows[i].copy_button.disabled = true;
+        if(this.rows[i].toggle_button) this.rows[i].toggle_button.disabled = true;
       }
     }
     this._super();

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -42,7 +42,7 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
       if(this.remove_all_rows_button) this.remove_all_rows_button.disabled = false;
       if(this.delete_last_row_button) this.delete_last_row_button.disabled = false;
       if(this.copy_button) this.copy_button.disabled = false;
-      if(this.toggle_button) this.toggle_button.disabled = false;
+      //if(this.toggle_button) this.toggle_button.disabled = false;
       if(this.delete_button) this.delete_button.disabled = false;
       if(this.moveup_button) this.moveup_button.disabled = false;
       if(this.movedown_button) this.movedown_button.disabled = false;
@@ -51,11 +51,11 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
         for(var i=0; i<this.rows.length; i++) {
           this.rows[i].enable();
 
-          if(this.rows[i].moveup_button) this.rows[i].moveup_button.disabled = false;
-          if(this.rows[i].movedown_button) this.rows[i].movedown_button.disabled = false;
-          if(this.rows[i].delete_button) this.rows[i].delete_button.disabled = false;
+          if(this.rows[i].add_row_button) this.rows[i].add_row_button.disabled = false;
+          if(this.rows[i].remove_all_rows_button) this.rows[i].remove_all_rows_button.disabled = false;
+          if(this.rows[i].delete_last_row_button) this.rows[i].delete_last_row_button.disabled = false;
           if(this.rows[i].copy_button) this.rows[i].copy_button.disabled = false;
-          if(this.rows[i].toggle_button) this.rows[i].toggle_button.disabled = false;
+          //if(this.rows[i].toggle_button) this.rows[i].toggle_button.disabled = false;
           if(this.rows[i].delete_button) this.rows[i].delete_button.disabled = false;
           if(this.rows[i].moveup_button) this.rows[i].moveup_button.disabled = false;
           if(this.rows[i].movedown_button) this.rows[i].movedown_button.disabled = false;
@@ -70,17 +70,25 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
     if(this.remove_all_rows_button) this.remove_all_rows_button.disabled = true;
     if(this.delete_last_row_button) this.delete_last_row_button.disabled = true;
     if(this.copy_button) this.copy_button.disabled = true;
-    if(this.toggle_button) this.toggle_button.disabled = true;
+    //if(this.toggle_button) this.toggle_button.disabled = true;
+    if(this.delete_button) this.delete_button.disabled = true;
+    if(this.moveup_button) this.moveup_button.disabled = true;
+    if(this.movedown_button) this.movedown_button.disabled = true;
+
 
     if(this.rows) {
       for(var i=0; i<this.rows.length; i++) {
         this.rows[i].disable(always_disabled);
 
-        if(this.rows[i].moveup_button) this.rows[i].moveup_button.disabled = true;
-        if(this.rows[i].movedown_button) this.rows[i].movedown_button.disabled = true;
-        if(this.rows[i].delete_button) this.rows[i].delete_button.disabled = true;
+        if(this.rows[i].add_row_button) this.rows[i].add_row_button.disabled = true;
+        if(this.rows[i].remove_all_rows_button) this.rows[i].remove_all_rows_button.disabled = true;
+        if(this.rows[i].delete_last_row_button) this.rows[i].delete_last_row_button.disabled = true;
         if(this.rows[i].copy_button) this.rows[i].copy_button.disabled = true;
-        if(this.rows[i].toggle_button) this.rows[i].toggle_button.disabled = true;
+        //if(this.rows[i].toggle_button) this.rows[i].toggle_button.disabled = true;
+        if(this.rows[i].delete_button) this.rows[i].delete_button.disabled = true;
+        if(this.rows[i].moveup_button) this.rows[i].moveup_button.disabled = true;
+       if(this.rows[i].movedown_button) this.rows[i].movedown_button.disabled = true;
+
       }
     }
     this._super();

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -562,8 +562,11 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     }
     // If the object should be rendered as a div
     else {
-      this.header = document.createElement('label');
-      this.header.textContent = this.getTitle();
+      this.header = '';
+      if(!this.options.compact) {
+        this.header = document.createElement('label');
+        this.header.textContent = this.getTitle();
+      }
       this.title = this.theme.getHeader(this.header);
       this.container.appendChild(this.title);
       this.container.style.position = 'relative';
@@ -759,10 +762,10 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
 
       // Collapse button disabled
       if(this.schema.options && typeof this.schema.options.disable_collapse !== "undefined") {
-        if(this.schema.options.disable_collapse) this.toggle_button.style.display = 'none';
+        if(this.schema.options.disable_collapse) this.title_controls.style.display = 'none';
       }
       else if(this.jsoneditor.options.disable_collapse) {
-        this.toggle_button.style.display = 'none';
+        this.title_controls.style.display = 'none';
       }
 
       // Edit JSON Button
@@ -778,10 +781,10 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
 
       // Edit JSON Buttton disabled
       if(this.schema.options && typeof this.schema.options.disable_edit_json !== "undefined") {
-        if(this.schema.options.disable_edit_json) this.editjson_button.style.display = 'none';
+        if(this.schema.options.disable_edit_json) this.editjson_controls.style.display = 'none';
       }
       else if(this.jsoneditor.options.disable_edit_json) {
-        this.editjson_button.style.display = 'none';
+        this.editjson_controls.style.display = 'none';
       }
 
       // Object Properties Button


### PR DESCRIPTION
- Add support for `compact` in `src/objects.js` to hide title.
- Adds missing buttons to enable/disable state (src/array.js)
- Fixed problems with `dependencies` option not working with Boolean format (src/editor.js).  Test Case: https://is.gd/WzAiQq
- Fixes problem with JSON and collapse buttons setting `display: none;` on button and not container (properties button was only one that did it correctly. (src/object.js)

So now  `compact` in combination with hiding the buttons, will remove the "empty gap" in the layout.