### PR TITLE
Fix of #231 - Allow use of dots in fieldnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Current
 
+  - Fiexd of #231 - Now it is possible to use dots in field names (src/editor.js)
   - Added new editor for uuid. If no uuid is supplied (startval), a random generated V4 uuid is created.
   - Added support for compact option in src/objects.js to hide title.
   - Added missing buttons to enable/disable state (src/array.js)

--- a/src/editor.js
+++ b/src/editor.js
@@ -66,8 +66,8 @@ JSONEditor.AbstractEditor = Class.extend({
     this.path = options.path || 'root';
     this.formname = options.formname || this.path.replace(/\.([^.]+)/g,'[$1]');
     if(this.jsoneditor.options.form_name_root) this.formname = this.formname.replace(/^root\[/,this.jsoneditor.options.form_name_root+'[');
-    this.key = this.path.split('.').pop();
     this.parent = options.parent;
+    this.key = this.parent !== undefined ? this.path.split('.').slice(this.parent.path.split('.').length).join('.') : this.path;
 
     this.link_watchers = [];
 


### PR DESCRIPTION
Fix of #231 - Allow use of dots "." in fieldnames.
Test Case: https://is.gd/P5sGXD
Before patch, label is "ackTimeout" (wrong)
After patch, label is "-Dsun.rmi.dgc.ackTimeout" (correct)