### PR TITLE
Fix of #392 - Checkbox failed to call onchange correctly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Current
 
-  - Fiexd of #231 - Now it is possible to use dots in field names (src/editor.js)
+  - Fixed #392 - Now setting checkbox value programmatically will trigger onchange correctly. (src/editors/checkbox.js)
+  - Fixed #231 - Now it is possible to use dots in field names (src/editor.js)
   - Added new editor for uuid. If no uuid is supplied (startval), a random generated V4 uuid is created.
   - Added support for compact option in src/objects.js to hide title.
   - Added missing buttons to enable/disable state (src/array.js)

--- a/src/editors/checkbox.js
+++ b/src/editors/checkbox.js
@@ -1,8 +1,10 @@
 JSONEditor.defaults.editors.checkbox = JSONEditor.AbstractEditor.extend({
   setValue: function(value,initial) {
-    this.value = !!value;
+    value = !!value;
+    var changed = this.getValue() !== value;
+    this.value = value;
     this.input.checked = this.value;
-    this.onChange();
+    this.onChange(changed);
   },
   register: function() {
     this._super();


### PR DESCRIPTION
Fixed #392 - Now setting checkbox value programmatically will trigger onchange correctly. (src/editors/checkbox.js)