### PR TITLE
Fix datetime integer setValue fails to update internal state

### DIFF
--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -114,6 +114,7 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
       else if (this.schema.format == 'time') dateValue = time;
 
       this.input.value = dateValue;
+      this.refreshValue();
       if (this.flatpickr) this.flatpickr.setDate(dateValue);
     }
   },


### PR DESCRIPTION
Datetime fields of integer type fail to update the internal state (``this.value``) when ``setValue`` is called.

Steps to reproduce:

Create editor with schema: ``{"type": "integer",  "format": "datetime-local"}``
``editor.setValue(1562320800)``
``editor.getValue()`` will be ``undefined``
