### PR TITLE
Sanitize value of choices editors and cleanup

### DIFF
--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -34,6 +34,9 @@ JSONEditor.defaults.editors.datetime = JSONEditor.defaults.editors.string.extend
       // Attribute for flatpicker
       this.input.setAttribute('data-input','');
 
+      // disable autocomplete
+      this.input.setAttribute('autocomplete','off');
+
       var input = this.input;
 
       if (this.options.flatpickr.wrap === true) {


### PR DESCRIPTION
- When the type of a field is not a string type (i.e. integer) changing the value or adding/removing array elements converts the internal value to string. This change will sanitize the internal state to the type defined by the schema.
- Array values can now be differently titled.
- Some code cleanup and simplification. When implementing support for Choices I just copied the Selectize implementation and went on from there getting it into a working state. I didn't take the time then to properly go through the code.
- Fixes #402 (was reproducible by me )