### PR TITLE
Allow setting custom validation message for patterns

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -313,7 +313,7 @@ JSONEditor.Validator = Class.extend({
           errors.push({
             path: path,
             property: 'pattern',
-            message: this.translate('error_pattern', [schema.pattern])
+            message: (schema.options && schema.options.patternmessage) ? schema.options.patternmessage : this.translate('error_pattern', [schema.pattern])
           });
         }
       }


### PR DESCRIPTION
**Non-BC**

Adds new option parameter for overriding the error message generated when using patterns.
The normal errors when using patterns looks something like this (Which isn't very informative for non-programmers):
``
Value must match the pattern ^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]).){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$.
``

With this PR, you can set `options.patternmessage` to an alternate text which will then be displayed instead.

