### PR TITLE
Ipeditor

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,6 +69,7 @@ module.exports = function(grunt) {
           'src/editors/radio.js',
           'src/editors/describedby.js',
           'src/editors/uuid.js',
+          'src/editors/ip.js',  
 
           // All the themes and iconlibs
           'src/theme.js',

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -179,6 +179,14 @@ JSONEditor.defaults.languages.en = {
    * When a integer date is less than 1 January 1970
    */
   error_invalid_epoch: 'Date must be greater than 1 January 1970',
+  /**
+   * When an IPv4 is in incorrect format
+   */
+  error_ipv4: 'Value must be a valid IPv4 address in the form of 4 numbers between 0 and 255, separated by dots',
+  /**
+   * When an IPv6 is in incorrect format
+   */
+  error_ipv6: 'Value must be a valid IPv6 address',
 
   /**
    * Text on Delete All buttons
@@ -407,4 +415,7 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
 // Enable custom editor type
 JSONEditor.defaults.resolvers.unshift(function(schema) {
   if (schema.type === "string" && schema.format === "uuid") return "uuid";
+});
+JSONEditor.defaults.resolvers.unshift(function(schema) {
+  if (schema.type === "string" && ['ip', 'ipv4', 'ipv6'].indexOf(schema.format) !== -1 ) return "ip";
 });

--- a/src/editors/ip.js
+++ b/src/editors/ip.js
@@ -1,0 +1,34 @@
+JSONEditor.defaults.editors.ip = JSONEditor.defaults.editors.string.extend({
+  preBuild: function() {
+    this._super();
+    var pattern, patternmessage;
+
+    if (this.schema.format == 'ipv6') {
+      pattern = '^(?:(?:(?:[a-fA-F0-9]{1,4}:){6}|(?=(?:[a-fA-F0-9]{0,4}:){2,6}(?:[0-9]{1,3}\.){3}[0-9]{1,3}$)(([0-9a-fA-F]{1,4}:){1,5}|:)((:[0-9a-fA-F]{1,4}){1,5}:|:)|::(?:[a-fA-F0-9]{1,4}:){5})(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])|(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}|(?=(?:[a-fA-F0-9]{0,4}:){0,7}[a-fA-F0-9]{0,4}$)(([0-9a-fA-F]{1,4}:){1,7}|:)((:[0-9a-fA-F]{1,4}){1,7}|:)|(?:[a-fA-F0-9]{1,4}:){7}:|:(:[a-fA-F0-9]{1,4}){7})$';
+      patternmessage = this.options.patternmessage || this.translate('error_ipv6');
+      // Set cleave options if no existing options is present
+      if (!this.schema.options.cleave) this.schema.options.cleave = {
+          delimiters: [':'],
+          blocks: [4, 4, 4, 4, 4, 4, 4, 4],
+          uppercase: true
+        };
+    }
+    else {
+      pattern = '^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$';
+      patternmessage = this.options.patternmessage || this.translate('error_ipv4');
+      // Set cleave options if no existing options is present
+      if (!this.schema.options.cleave) this.schema.options.cleave = {
+          delimiters: ['.'],
+          blocks: [3, 3, 3, 3],
+          numericOnly: true
+        };
+    }
+
+    // Set custom pattern error validation message
+    this.options.patternmessage = this.jsoneditor.validator.schema.properties[this.key].options.patternmessage = patternmessage;
+
+    // Force pattern validation
+    this.jsoneditor.validator.schema.properties[this.key].pattern = this.schema.pattern = pattern;
+
+  }
+});

--- a/src/editors/ip.js
+++ b/src/editors/ip.js
@@ -7,7 +7,7 @@ JSONEditor.defaults.editors.ip = JSONEditor.defaults.editors.string.extend({
       pattern = '^(?:(?:(?:[a-fA-F0-9]{1,4}:){6}|(?=(?:[a-fA-F0-9]{0,4}:){2,6}(?:[0-9]{1,3}\.){3}[0-9]{1,3}$)(([0-9a-fA-F]{1,4}:){1,5}|:)((:[0-9a-fA-F]{1,4}){1,5}:|:)|::(?:[a-fA-F0-9]{1,4}:){5})(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])|(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}|(?=(?:[a-fA-F0-9]{0,4}:){0,7}[a-fA-F0-9]{0,4}$)(([0-9a-fA-F]{1,4}:){1,7}|:)((:[0-9a-fA-F]{1,4}){1,7}|:)|(?:[a-fA-F0-9]{1,4}:){7}:|:(:[a-fA-F0-9]{1,4}){7})$';
       patternmessage = this.options.patternmessage || this.translate('error_ipv6');
       // Set cleave options if no existing options is present
-      if (!this.schema.options.cleave) this.schema.options.cleave = {
+      if (this.schema.options && !this.schema.options.cleave) this.schema.options.cleave = {
           delimiters: [':'],
           blocks: [4, 4, 4, 4, 4, 4, 4, 4],
           uppercase: true
@@ -17,7 +17,7 @@ JSONEditor.defaults.editors.ip = JSONEditor.defaults.editors.string.extend({
       pattern = '^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$';
       patternmessage = this.options.patternmessage || this.translate('error_ipv4');
       // Set cleave options if no existing options is present
-      if (!this.schema.options.cleave) this.schema.options.cleave = {
+      if (this.schema.options && !this.schema.options.cleave) this.schema.options.cleave = {
           delimiters: ['.'],
           blocks: [3, 3, 3, 3],
           numericOnly: true
@@ -25,6 +25,7 @@ JSONEditor.defaults.editors.ip = JSONEditor.defaults.editors.string.extend({
     }
 
     // Set custom pattern error validation message
+    if (!this.jsoneditor.validator.schema.properties[this.key].options) this.jsoneditor.validator.schema.properties[this.key].options = {};
     this.options.patternmessage = this.jsoneditor.validator.schema.properties[this.key].options.patternmessage = patternmessage;
 
     // Force pattern validation

--- a/src/editors/uuid.js
+++ b/src/editors/uuid.js
@@ -9,6 +9,13 @@ JSONEditor.defaults.editors.uuid = JSONEditor.defaults.editors.string.extend({
     // Force pattern validation
     this.jsoneditor.validator.schema.properties[this.key].pattern = this.schema.pattern = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$';
 
+    // Set cleave options if no existing options is present
+    if (!this.schema.options) this.schema.options = {};
+    if (!this.schema.options.cleave) this.schema.options.cleave = {
+        delimiters: ['-'],
+        blocks: [8, 4, 4, 4, 12]
+      };
+
     // Set field to readonly and hide field, label and description
     //this.schema.readonly = this.options.compact = this.options.hidden = true;
   },

--- a/src/validator.js
+++ b/src/validator.js
@@ -313,7 +313,7 @@ JSONEditor.Validator = Class.extend({
           errors.push({
             path: path,
             property: 'pattern',
-            message: this.translate('error_pattern', [schema.pattern])
+            message: (schema.options && schema.options.patternmessage) ? schema.options.patternmessage : this.translate('error_pattern', [schema.pattern])
           });
         }
       }


### PR DESCRIPTION
* Supports validation of IPv4 & IPv6 (setting "format" to "ipv6", ipv4" or "ip" (last one is alias for "ipv4")
* Adds custom formatting options if Cleave.js is loaded and no cleave options have been set. (splits input into separated blocks etc.)
* Uses the build-in pattern validation.
* Error messages can be overridden #425

Schema example. 
````json
{
  "title": "IP Editor example",
  "type": "object",
  "properties": {
    "ipversion4": {
      "type": "string",
      "format": "ipv4"
    },
    "ipversion6": {
      "type": "string",
      "format": "ipv6"
    },
    "ip": {
      "type": "string",
      "format": "ip",
      "options": {
        "patternmessage": "This is a custom error message that replaces the standard pattern error message"
      }
    }
  }
}
````