### PR TITLE
Allow more than one layer of allOf inheritance

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,7 @@ $ npm run build
 $ codeceptjs run
 ```
 
+Tests whose `Scenario` string contains the tag `@optional` will be ignored by the automated build process.
 
 ### References
 

--- a/tests/codeceptjs/editors/inheritance_test.js
+++ b/tests/codeceptjs/editors/inheritance_test.js
@@ -1,0 +1,11 @@
+var assert = require('assert');
+
+Feature('inheritance');
+
+Scenario('should display all required fields in the allOf hierarchy', async (I) => {
+  I.amOnPage('inheritance.html');
+  I.seeElement('[data-schemapath="root.breed"]');
+  I.seeElement('[data-schemapath="root.numLegs"]');
+  I.seeElement('[data-schemapath="root.id"]');
+});
+

--- a/tests/pages/inheritance.html
+++ b/tests/pages/inheritance.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <script src="../../dist/jsoneditor.js"></script>
+</head>
+<body>
+
+<textarea class="value" cols="30" rows="10"></textarea>
+<button class='get-value'>get value</button>
+<div class='container'></div>
+
+<script>
+  var container = document.querySelector('.container');
+  var value = document.querySelector('.value');
+  var getValue = document.querySelector('.get-value');
+
+  var schema = {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "definitions": {
+          "animal": {
+              "type": "object",
+              "properties": {
+                  "id": {
+                      "type": "number"
+                  }
+              },
+              "required": [
+                  "id"
+              ]
+          },
+          "landAnimal": {
+              "allOf": [
+                  {
+                      "$ref": "#/definitions/animal"
+                  }
+              ],
+              "type": "object",
+              "title": "Land Animal",
+              "properties": {
+                  "numLegs": {
+                      "type": "integer"
+                  }
+              },
+              "required": [
+                  "numLegs"
+              ]
+          }
+      },
+      "allOf": [
+          {
+              "$ref": "#/definitions/landAnimal"
+          }
+      ],
+      "type": "object",
+      "title": "Cat",
+      "properties":{
+          "breed":{"type":"string"}
+      },
+      "required":["breed"]
+  };
+
+  var editor = new JSONEditor(container, {
+    schema: schema,
+    show_errors: 'always'
+  });
+
+  getValue.addEventListener('click', function () {
+    value.value = JSON.stringify(editor.getValue());
+    console.log(editor.getValue());
+  });
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes #422.

The changes required were fortunately fairly simple.

I've added a stub e2e test which simply checks all `required` fields in a two-layer hierarchy are added.

I scratched my head for about an hour wondering why four other e2e tests were failing and eventually worked out they were failing in the main repo too, but were being ignored by Travis because of the `@optional` tag. So I added some text to `./testing/README.md` to point this out to future contributors.