### PR TITLE
Radiorefactor

### DIFF
--- a/src/editors/radio.js
+++ b/src/editors/radio.js
@@ -1,4 +1,4 @@
-JSONEditor.defaults.editors.radio = JSONEditor.defaults.editors.string.extend({
+JSONEditor.defaults.editors.radio = JSONEditor.defaults.editors.select.extend({
   build: function () {
     var self = this;
 
@@ -9,7 +9,6 @@ JSONEditor.defaults.editors.radio = JSONEditor.defaults.editors.string.extend({
 
     this.radioContainer = document.createElement('div');
 
-    this.enum_values = this.schema.enum;
     this.radioGroup = [];
 
     var radioInputEventhandler = function(e) {
@@ -39,7 +38,7 @@ JSONEditor.defaults.editors.radio = JSONEditor.defaults.editors.string.extend({
 
       // contains the displayed text to the label
       var radioLabelText = document.createElement('span');
-      radioLabelText.innerText = this.enum_values[i];
+      radioLabelText.innerText = this.enum_display[i];
       radioLabelText.classList.add('radio__label');
 
       // permits the addition of styles for the radio itself (if you want it to look differently than browser default)

--- a/src/editors/radio.js
+++ b/src/editors/radio.js
@@ -23,33 +23,24 @@ JSONEditor.defaults.editors.radio = JSONEditor.defaults.editors.select.extend({
       var id = this.key + '-' + i;
 
       // form radio elements
-      var radioInput = this.theme.getFormInputField('radio');
-      radioInput.name = this.formname;
-      radioInput.value = this.enum_values[i];
-      radioInput.id = id;
-      radioInput.classList.add('radio__field');
-      radioInput.addEventListener('change', radioInputEventhandler, false);
-      this.radioGroup.push(radioInput);
+      this.input = this.theme.getFormInputField('radio');
+      this.input.name = this.formname;
+      this.input.value = this.enum_values[i];
+      this.input.id = id;
+
+      // Set custom attributes on input element. Parameter is array of protected keys. Empty array if none.
+      this.setInputAttributes(['id', 'value', 'name']);
+
+
+      this.input.addEventListener('change', radioInputEventhandler, false);
+      this.radioGroup.push(this.input);
 
       // form-label for radio elements
-      var radioLabel = document.createElement('label');
+      var radioLabel = this.theme.getFormInputLabel(this.enum_display[i]);
       radioLabel.htmlFor = id;
-      radioLabel.classList.add('radio');
 
-      // contains the displayed text to the label
-      var radioLabelText = document.createElement('span');
-      radioLabelText.innerText = this.enum_display[i];
-      radioLabelText.classList.add('radio__label');
+      this.radioContainer.appendChild(this.theme.getFormControl(radioLabel, this.input, this.description));
 
-      // permits the addition of styles for the radio itself (if you want it to look differently than browser default)
-      var radioLabelIcon = document.createElement('span');
-      radioLabelIcon.classList.add('radio__icon');
-
-      radioLabel.appendChild(radioInput);
-      radioLabel.appendChild(radioLabelIcon);
-      radioLabel.appendChild(radioLabelText);
-
-      this.radioContainer.appendChild(radioLabel);
     }
 
     if(this.schema.readOnly || this.schema.readonly) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -203,7 +203,8 @@ JSONEditor.AbstractTheme = Class.extend({
     var el = document.createElement('div');
     el.classList.add('form-control');
     if(label) el.appendChild(label);
-    if(input.type === 'checkbox' && label) {
+    if((input.type === 'checkbox' || input.type === 'radio') && label) {
+      input.style.width = 'auto';  
       label.insertBefore(input,label.firstChild);
       if(infoText) label.appendChild(infoText);
     }

--- a/src/themes/bootstrap2.js
+++ b/src/themes/bootstrap2.js
@@ -95,20 +95,23 @@ JSONEditor.defaults.themes.bootstrap2 = JSONEditor.AbstractTheme.extend({
   },
   getFormControl: function(label, input, description, infoText) {
     var ret = document.createElement('div');
-    ret.classList.add('control-group');
 
     var controls = document.createElement('div');
-    controls.classList.add('controls');
 
-    if(label && input.getAttribute('type') === 'checkbox') {
+    if(label && (input.getAttribute('type') === 'checkbox' || input.getAttribute('type') === 'radio')) {
       ret.appendChild(controls);
-      label.classList.add('checkbox');
-      label.appendChild(input);
+      controls.classList.add('form-check');
+      label.classList.add('form-check-label');
+      input.classList.add('form-check-input');
+      input.style.margin = '0 4px 4px 0';
+      input.style.width = 'auto';
+      controls.appendChild(input);
       controls.appendChild(label);
       if(infoText) controls.appendChild(infoText);
       controls.style.height = '30px';
     }
     else {
+    ret.classList.add('control-group');
       if(label) {
         label.classList.add('control-label');
         ret.appendChild(label);

--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -36,36 +36,29 @@ JSONEditor.defaults.themes.bootstrap3 = JSONEditor.AbstractTheme.extend({
   },
   getFormInputField: function(type) {
     var el = this._super(type);
-    if(type !== 'checkbox') {
-      el.classList.add('form-control');
+    if (type !== "checkbox" && type !== "radio") {
+      el.classList.add("form-control");
     }
     return el;
   },
-  getFormControl: function(label, input, description, infoText) {
-    var group = document.createElement('div');
+  getFormControl: function(label, input, description) {
+    var group = document.createElement("div");
 
-    if(label && input.type === 'checkbox') {
-      group.classList.add('checkbox');
-      label.appendChild(input);
-      label.style.fontSize = '14px';
-      group.style.marginTop = '0';
-      if(infoText) group.appendChild(infoText);
+    if (label && (input.type === "checkbox" || input.type === "radio")) {
+      group.classList.add(input.type);
+      label.insertBefore(input, label.firstChild);
       group.appendChild(label);
-      input.style.position = 'relative';
-      input.style.cssFloat = 'left';
     }
     else {
-      group.classList.add('form-group');
-      if(label) {
-        label.classList.add('control-label');
+      group.classList.add("form-group");
+      if (label) {
+        label.classList.add("control-label");
         group.appendChild(label);
       }
-
-      if(infoText) group.appendChild(infoText);
       group.appendChild(input);
     }
 
-    if(description) group.appendChild(description);
+    if (description) group.appendChild(description);
 
     return group;
   },

--- a/src/themes/bootstrap4.js
+++ b/src/themes/bootstrap4.js
@@ -31,7 +31,7 @@ JSONEditor.defaults.themes.bootstrap4 = JSONEditor.AbstractTheme.extend({
   },
   getFormInputField: function(type) {
     var el = this._super(type);
-    if (type !== "checkbox") {
+    if (type !== "checkbox" && type !== "radio") {
       el.classList.add("form-control");
     }
     return el;
@@ -39,15 +39,15 @@ JSONEditor.defaults.themes.bootstrap4 = JSONEditor.AbstractTheme.extend({
   getFormControl: function(label, input, description) {
     var group = document.createElement("div");
 
-    if (label && input.type === "checkbox") {
-      group.classList.add("checkbox");
-      label.appendChild(input);
-      label.style.fontSize = "14px";
-      group.style.marginTop = "0";
+    if (label && (input.type === "checkbox" || input.type === "radio")) {
+      group.classList.add("form-check");
+      label.classList.add("form-check-label");
+      input.classList.add("form-check-input");
+      //label.appendChild(input);
+      label.insertBefore(input, label.firstChild);
       group.appendChild(label);
-      input.style.position = "relative";
-      input.style.cssFloat = "left";
-    } else {
+    }
+    else {
       group.classList.add("form-group");
       if (label) {
         label.classList.add("form-control-label");

--- a/src/themes/foundation.js
+++ b/src/themes/foundation.js
@@ -37,7 +37,7 @@ JSONEditor.defaults.themes.foundation = JSONEditor.AbstractTheme.extend({
   getFormInputField: function(type) {
     var el = this._super(type);
     el.style.width = '100%';
-    el.style.marginBottom = type==='checkbox'? '0' : '12px';
+    el.style.marginBottom = (type==='checkbox' || type==='radio')? '0' : '12px';
     return el;
   },
   getFormInputDescription: function(text) {
@@ -372,7 +372,8 @@ JSONEditor.defaults.themes.foundation6 = JSONEditor.defaults.themes.foundation5.
     var el = document.createElement('div');
     el.classList.add('form-control');
     if(label) el.appendChild(label);
-    if(input.type === 'checkbox') {
+    if(input.type === 'checkbox' || input.type === 'radio') {
+      input.style.width = 'auto';
       label.insertBefore(input,label.firstChild);
     }
     else if (label) {

--- a/src/themes/materialize.js
+++ b/src/themes/materialize.js
@@ -76,7 +76,7 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
       type = input.type;
 
       // Checkboxes get wrapped in p elements.
-      if (type && type === 'checkbox') {
+      if (type && (type === 'checkbox' || type === 'radio')) {
 
         ctrl = document.createElement('p');
         if (label) {

--- a/src/themes/tailwind.js
+++ b/src/themes/tailwind.js
@@ -69,7 +69,7 @@ JSONEditor.defaults.themes.tailwind = JSONEditor.AbstractTheme.extend({
     },
     getFormInputField: function (type) {
         var el = this._super(type);
-        if (type !== "checkbox") {
+        if (type !== "checkbox" && type !== "radio") {
             el.classList.add(
                 "block",
                 "w-full",
@@ -95,12 +95,12 @@ JSONEditor.defaults.themes.tailwind = JSONEditor.AbstractTheme.extend({
     getFormControl: function (label, input, description) {
         var group = document.createElement("div");
 
-        if (label && input.type === "checkbox") {
-            group.classList.add("checkbox", "mt-0");
+        if (label &&( input.type === "checkbox" || input.type === "radio")) {
+            group.classList.add(input.type, "mt-0");
             label.appendChild(input);
             label.classList.add("block", "mt-0", "text-xs");
             group.appendChild(label);
-            input.classList.add("relative", "float-left");
+            input.classList.add("relative", "float-left", "mr-1");
         } else {
             group.classList.add("form-group", "mb-2");
             if (label) {


### PR DESCRIPTION
**Refactored radio editor** (Fixes issues described in #420)

* Now extends `select` editor instead of `string` editor, which handles all `enum` variants.
* Added support for `inputAttributes` option.
* Moved rendering of elements from editor (hardcoded) to theme functions.
* Updated `checkbox` and `radio` rendering in all themes.