### PR TITLE
fixbug: when value has errors with validators, anyOf can not choose t…

### DIFF
--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -264,7 +264,7 @@ JSONEditor.defaults.editors.multiple = JSONEditor.AbstractEditor.extend({
       if (!validator.validate(val).length) {
         if (validVal.i === null){
           validVal.i = i;
-          if (typeof fitTestResult !== null){
+          if (fitTestResult !== null){
             validVal.match = fitTestResult.match;
           }
         }
@@ -279,7 +279,7 @@ JSONEditor.defaults.editors.multiple = JSONEditor.AbstractEditor.extend({
       }
     }
     if (finalI === null) {
-      finalI = this.type
+      finalI = this.type;
     }
     this.type = finalI;
     this.switcher.value = this.display_text[finalI];

--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -248,8 +248,9 @@ JSONEditor.defaults.editors.multiple = JSONEditor.AbstractEditor.extend({
       i: null
     };
     $each(this.validators, function (i, validator) {
+      var fitTestResult = null;
       if (typeof self.anyOf !== "undefined" && self.anyOf) {
-        var fitTestResult = validator.fitTest(val);
+        fitTestResult = validator.fitTest(val);
         if (fitTestVal.match < fitTestResult.match) {
           fitTestVal = fitTestResult;
           fitTestVal.i = i;
@@ -263,7 +264,7 @@ JSONEditor.defaults.editors.multiple = JSONEditor.AbstractEditor.extend({
       if (!validator.validate(val).length) {
         if (validVal.i === null){
           validVal.i = i;
-          if (typeof fitTestResult !== "undefined"){
+          if (typeof fitTestResult !== null){
             validVal.match = fitTestResult.match;
           }
         }

--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -261,12 +261,10 @@ JSONEditor.defaults.editors.multiple = JSONEditor.AbstractEditor.extend({
           }
         }
       }
-      if (!validator.validate(val).length) {
-        if (validVal.i === null){
-          validVal.i = i;
-          if (fitTestResult !== null){
-            validVal.match = fitTestResult.match;
-          }
+      if (!validator.validate(val).length && validVal.i === null) {
+        validVal.i = i;
+        if (fitTestResult !== null){
+          validVal.match = fitTestResult.match;
         }
       }
     });


### PR DESCRIPTION
fixbug: when value has errors with validators, anyOf can not choose the right one.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #444 when data more complex

Bad case: https://is.gd/BLyoQH

expect:
the first element should use `item a`
actual:
the first element use `item c`

reason:
when set value to editor, if something wrong with value, the fit test is ignored.

code: https://github.com/json-editor/json-editor/blob/0ca9b61cf02a4fc4ba55327c5e02bca58771341a/src/editors/multiple.js#L247