### PR TITLE
Fix overlapping label for radio and range Materialize theme (fixes #205)

### DIFF
--- a/src/editors/radio.js
+++ b/src/editors/radio.js
@@ -85,6 +85,11 @@ JSONEditor.defaults.editors.radio = JSONEditor.defaults.editors.select.extend({
     this.radioContainer.classList.add('readonly');
     this._super();
   },
+  afterInputReady: function() {
+    var self = this;
+    self.input.dataset.containerFor = 'radio';
+    self.theme.afterInputReady(self.input);
+  },
   destroy: function() {
     if(this.radioContainer.parentNode && this.radioContainer.parentNode.parentNode) this.radioContainer.parentNode.parentNode.removeChild(this.radioContainer.parentNode);
     if(this.label && this.label.parentNode) this.label.parentNode.removeChild(this.label);

--- a/src/editors/radio.js
+++ b/src/editors/radio.js
@@ -55,6 +55,7 @@ JSONEditor.defaults.editors.radio = JSONEditor.defaults.editors.select.extend({
 
     var radioContainerWrapper = this.theme.getContainer();
     radioContainerWrapper.appendChild(this.radioContainer);
+    radioContainerWrapper.dataset.containerFor = 'radio';
 
     this.input = radioContainerWrapper;
 

--- a/src/editors/radio.js
+++ b/src/editors/radio.js
@@ -85,11 +85,6 @@ JSONEditor.defaults.editors.radio = JSONEditor.defaults.editors.select.extend({
     this.radioContainer.classList.add('readonly');
     this._super();
   },
-  afterInputReady: function() {
-    var self = this;
-    self.input.dataset.containerFor = 'radio';
-    self.theme.afterInputReady(self.input);
-  },
   destroy: function() {
     if(this.radioContainer.parentNode && this.radioContainer.parentNode.parentNode) this.radioContainer.parentNode.parentNode.removeChild(this.radioContainer.parentNode);
     if(this.label && this.label.parentNode) this.label.parentNode.removeChild(this.label);

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -195,7 +195,6 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
     var input = this.input;
     if(this.format === 'range') {
       input = this.theme.getRangeControl(this.input, this.theme.getRangeOutput(this.input, this.schema.default || Math.max(this.schema.minimum || 0, 0)));
-      input.dataset.containerFor = this.format;
     }
 
     this.control = this.theme.getFormControl(this.label, input, this.description, this.infoButton);

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -195,6 +195,7 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
     var input = this.input;
     if(this.format === 'range') {
       input = this.theme.getRangeControl(this.input, this.theme.getRangeOutput(this.input, this.schema.default || Math.max(this.schema.minimum || 0, 0)));
+      input.dataset.containerFor = this.format;
     }
 
     this.control = this.theme.getFormControl(this.label, input, this.description, this.infoButton);

--- a/src/themes/materialize.js
+++ b/src/themes/materialize.js
@@ -82,6 +82,13 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
       var ctrl,
       type = input.type;
 
+      // Fix overlapping label
+      if (input.dataset.containerFor && (input.dataset.containerFor === 'radio' || input.dataset.containerFor === 'range')) {
+        if(label){
+          label.classList.add('active'); 
+        }
+      }
+      
       // Checkboxes get wrapped in p elements.
       if (type && (type === 'checkbox' || type === 'radio')) {
 

--- a/src/themes/materialize.js
+++ b/src/themes/materialize.js
@@ -69,6 +69,11 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
 
   afterInputReady: function(input) {
       var label = input.previousSibling;
+
+      if(input.type && input.type === 'range'){
+        label = input.parentElement.previousSibling;
+      }
+
       if(input.value && label && label.localName === 'label'){
         label.classList.add('active'); 
       }
@@ -90,7 +95,7 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
       type = input.type;
 
       // Fix overlapping label
-      if (input.dataset.containerFor && (input.dataset.containerFor === 'radio' || input.dataset.containerFor === 'range')) {
+      if (input.dataset.containerFor && input.dataset.containerFor === 'radio') {
         if(label){
           label.classList.add('active'); 
         }

--- a/src/themes/materialize.js
+++ b/src/themes/materialize.js
@@ -67,16 +67,18 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
 
     },
 
-  afterInputReady: function(input) {
+    afterInputReady: function(input) {
       var label = input.previousSibling;
 
       if(input.type && input.type === 'range'){
         label = input.parentElement.previousSibling;
       }
 
-      if(input.value && label && label.localName === 'label'){
-        label.classList.add('active'); 
-      }
+      if(input.value || (input.dataset.containerFor && input.dataset.containerFor === 'radio')){
+        if(label && label.localName === 'label'){
+          label.classList.add('active'); 
+        }
+      } 
     },
 
     /**
@@ -93,13 +95,6 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
 
       var ctrl,
       type = input.type;
-
-      // Fix overlapping label
-      if (input.dataset.containerFor && input.dataset.containerFor === 'radio') {
-        if(label){
-          label.classList.add('active'); 
-        }
-      }
       
       // Checkboxes get wrapped in p elements.
       if (type && (type === 'checkbox' || type === 'radio')) {

--- a/src/themes/materialize.js
+++ b/src/themes/materialize.js
@@ -67,6 +67,13 @@ JSONEditor.defaults.themes.materialize = JSONEditor.AbstractTheme.extend(
 
     },
 
+  afterInputReady: function(input) {
+      var label = input.previousSibling;
+      if(input.value && label && label.localName === 'label'){
+        label.classList.add('active'); 
+      }
+    },
+
     /**
    * Gets a form control object consisiting of several sub objects.
    *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️ Good for 2.x
| Tests pass?   | Not run, shouldn't impact
| Fixed issues  | #205 

This is a partial fix for radio and range elements only. Tried to fix as generic as possible, added data-container-for attribute for element types wrapped in additional div, so that we know what's actually inside. This might be useful not only for Materialize theme in case some manipulation is needed in getFormControl() function.