### PR TITLE
Prevent memory leak

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -644,13 +644,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
       this.addproperty_holder.appendChild(spacer);
 
       // Close properties modal if clicked outside modal
-      document.addEventListener('click', function(e) {
-          if (!this.addproperty_holder.contains(e.target) && this.adding_property) {
-            e.preventDefault();
-            e.stopPropagation();
-            this.toggleAddProperty();
-          }
-      }.bind(this));
+      document.addEventListener('click', this.onOutsideModalClick);
 
       // Description
       if(this.schema.description) {
@@ -1035,6 +1029,13 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
       self.layoutEditors();
     }
   },
+  onOutsideModalClick: function() {
+    if (this.addproperty_holder && !this.addproperty_holder.contains(e.target) && this.adding_property) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.toggleAddProperty();
+    }
+  },
   onChildEditorChange: function(editor) {
     this.refreshValue();
     this._super(editor);
@@ -1057,6 +1058,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     this.cached_editors = null;
     if(this.editor_holder && this.editor_holder.parentNode) this.editor_holder.parentNode.removeChild(this.editor_holder);
     this.editor_holder = null;
+    document.removeEventListener('click', this.onOutsideModalClick);
 
     this._super();
   },


### PR DESCRIPTION
Prevent memory leak caused by attaching an anonymous listener to the document in object.js. Fixes #460 

Submitted this same PR an hour ago, realized a missed a line, then mucked up the commit trying to fix that mistake, so resubmitting.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #460 
