### PR TITLE
Added missing 'copy' icon. So errors are not thrown

### DIFF
--- a/src/iconlibs/bootstrap2.js
+++ b/src/iconlibs/bootstrap2.js
@@ -11,6 +11,7 @@ export var bootstrap2Iconlib = AbstractIconLib.extend({
     save: 'ok',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
+    copy: 'copy',
     clear: 'remove-circle',
     time: 'time',
     calendar: 'calendar'

--- a/src/iconlibs/bootstrap3.js
+++ b/src/iconlibs/bootstrap3.js
@@ -11,6 +11,7 @@ export var bootstrap3Iconlib = AbstractIconLib.extend({
     save: 'floppy-saved',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
+    copy: 'copy',
     clear: 'remove-circle',
     time: 'time',
     calendar: 'calendar'

--- a/src/iconlibs/fontawesome3.js
+++ b/src/iconlibs/fontawesome3.js
@@ -11,6 +11,7 @@ export var fontawesome3Iconlib = AbstractIconLib.extend({
     save: 'save',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
+    copy: 'copy',
     clear: 'remove-circle',
     time: 'time',
     calendar: 'calendar'

--- a/src/iconlibs/fontawesome5.js
+++ b/src/iconlibs/fontawesome5.js
@@ -4,7 +4,7 @@ export var fontawesome5Iconlib = AbstractIconLib.extend({
   mapping: {
     collapse: 'caret-down',
     expand: 'caret-right',
-    delete: 'times',
+    "delete": 'times',
     edit: 'pen',
     add: 'plus',
     cancel: 'ban',

--- a/src/iconlibs/foundation2.js
+++ b/src/iconlibs/foundation2.js
@@ -11,6 +11,7 @@ export var foundation2Iconlib = AbstractIconLib.extend({
     save: 'checkmark',
     moveup: 'up-arrow',
     movedown: 'down-arrow',
+    copy: 'page-copy',   
     clear: 'remove',
     time: 'clock',
     calendar: 'calendar'

--- a/src/iconlibs/foundation3.js
+++ b/src/iconlibs/foundation3.js
@@ -11,6 +11,7 @@ export var foundation3Iconlib = AbstractIconLib.extend({
     save: 'save',
     moveup: 'arrow-up',
     movedown: 'arrow-down',
+    copy: 'page-copy',
     clear: 'x-circle',
     time: 'clock',
     calendar: 'calendar'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

Iconsets without the "copy" property threw an error in some themes.