### PR TITLE
[WON"T MERGE] Remove obsolete code to illustrate breaking tests

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2,7 +2,7 @@ import './styles/choices.css';
 import './styles/starrating.css';
 
 import { ie9Polyfill } from './ie9';
-import { getDefaults, getPlugins } from './defaults';
+import { getDefaults } from './defaults';
 import { Validator } from './validator';
 import { $extend, $each } from './utilities';
 
@@ -834,7 +834,6 @@ JSONEditor.prototype = {
 
 ie9Polyfill();
 JSONEditor.defaults=getDefaults();
-JSONEditor.plugins=getPlugins();
 assignThemes(JSONEditor.defaults.themes);
 JSONEditor.AbstractEditor = AbstractEditor;
 assignDefaultEditors(JSONEditor.defaults.editors);

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -527,27 +527,3 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
 
 return JSONEditor.defaults;
 };
-
-// Miscellaneous Plugin Settings
-// Obsolete - Can be removed. Now replaced with global + schema options
-// DS: Actually it can't without breaking tests :-D
-export function getPlugins()  {
-  return {
-  ace: {
-    theme: ''
-  },
-  choices: {
-  },
-  SimpleMDE: {
-
-  },
-  sceditor: {
-
-  },
-  select2: {
-
-  },
-  selectize: {
-  }
-}
-};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  |❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ❌
| Referenced issues  | #491  
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

As requested by @schmunk42 in #491 

I have left breaking tests unmarked by @optional so that it is clear which ones are broken by the changes.
