### PR TITLE
Tests - Removed obsolete plugin reference and updated to use new options method

### DIFF
--- a/tests/pages/array-selectize.html
+++ b/tests/pages/array-selectize.html
@@ -14,7 +14,6 @@
 <div class='container'></div>
 
 <script>
-  JSONEditor.plugins.selectize.enable = true;
   var container = document.querySelector('.container');
   var debug = document.querySelector('.debug');
   var schema = {

--- a/tests/pages/string-ace-editor.html
+++ b/tests/pages/string-ace-editor.html
@@ -34,7 +34,9 @@
     }
   };
 
-  JSONEditor.plugins.ace.theme = 'twilight';
+  JSONEditor.defaults.options.ace = {
+    theme: 'ace/theme/twilight'
+  };
 
   var editor = new JSONEditor(container, {
     schema: schema

--- a/tests/pages/string-custom-attributes.html
+++ b/tests/pages/string-custom-attributes.html
@@ -43,10 +43,11 @@
 
   // sceditor quirk. Styles must be specified in the options at creation
   // if you want to be able to focus on the iframes he creates.
-
-  //JSONEditor.plugins.sceditor.style = '//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.default.min.css';
-  JSONEditor.plugins.sceditor.style = '';
-
+  JSONEditor.defaults.options.sceditor = {
+    //style: '//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.default.min.css'
+    style: ''
+  };
+  
   var editor = new JSONEditor(container, {
     schema: schema
   });

--- a/tests/pages/string-sceditor.html
+++ b/tests/pages/string-sceditor.html
@@ -33,9 +33,8 @@
       "properties": {
         "editor": {
           "type": "string",
-          "format": "html",
+          "format": "xhtml",
           "options": {
-            "wysiwyg": true
           }
         }
       }
@@ -45,9 +44,10 @@
   // sceditor quirk. Styles must be specified in the options at creation
   // if you want to be able to focus on the iframes he creates.
 
-  //JSONEditor.plugins.sceditor.style = '//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.default.min.css';
-  JSONEditor.plugins.sceditor.style = '';
-
+  JSONEditor.defaults.options.sceditor = {
+    //style: '//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.default.min.css'
+    style: ''
+  };
   var editor = new JSONEditor(container, {
     schema: schema
   });


### PR DESCRIPTION
I have removed obsolete plugin reference from tests and updated them to use new options method.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ✔️
| Tests pass?   | ✔️/❌
| Fixed issues  | #491
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

