### PR TITLE
Created separate production builds for amd and var

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -10,61 +10,74 @@ var helpers = require('./helpers');
 
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 
-module.exports = webpackMerge(commonConfig, {
-  mode: 'production',
-  output: {
-    path: helpers.root('dist'),
-    publicPath: '/dist/',
-    filename: '[name].js',
-    chunkFilename: '[id].chunk.js'
-  },
-
-  optimization:{
-    // Enabling splitChunks seems to stop the global JSONEditor object being set
-    /*
-    splitChunks:{
-      chunks:'all'
+function createConfig(target){
+  filenameInsert = target === 'var' ? '.' : '.' + target + '.';
+  return webpackMerge(commonConfig, {
+    mode: 'production',
+    output: {
+      path: helpers.root('dist'),
+      publicPath: '/dist/',
+      filename: '[name]' + filenameInsert + 'js',
+      chunkFilename: '[id]' + filenameInsert + 'chunk.js',
+      libraryTarget:target
+        // 'amd' // e2e n, import y
+        // 'var' // e2e y, import n
+        // 'assign' // e2e n, import n  
+        // 'global'  // e2e y, import 
     },
-    */
-    minimize:true
-  },
+  
+    optimization:{
+      // Enabling splitChunks seems to stop the global JSONEditor object being set
+      /*
+      splitChunks:{
+        chunks:'all'
+      },
+      */
+      minimize:true
+    },
+  
+    plugins: [
+      // new CleanWebpackPlugin({ // Clean all but dev subdirectory before building
+      //   cleanOnceBeforeBuildPatterns: ['**/*', 
+      //    // '!dev/**/*'      // doesn't work
+      //    '!dev/**'      // works
+      //   ],      
+      // }), 
+      new RemoveStrictPlugin(),           // I have put this in to avoid IE throwing error Assignment to read-only properties is not allowed in strict mode
+      // This doesn't seem to actually be minimising the CSS!
+      new OptimizeCSSAssetsPlugin({
+        cssProcessor: require('cssnano'),
+        cssProcessorPluginOptions: {
+          preset: ['default', { discardComments: { removeAll: true } }],
+        }/*,
+        canPrint: true*/
+      }),
+      new webpack.NoEmitOnErrorsPlugin(),
+      new MiniCssExtractPlugin({
+        // Options similar to the same options in webpackOptions.output
+        // all options are optional
+        filename: '[name].[hash].css',
+        chunkFilename: '[id].css',
+        ignoreOrder: false, // Enable to remove warnings about conflicting order
+      }),  
+      new webpack.DefinePlugin({
+        'process.env': {
+          'ENV': JSON.stringify(ENV)
+        }
+      })    
+    ],
+  
+    devServer: {
+      contentBase: helpers.root('.'),
+      historyApiFallback: true,
+      stats: 'minimal',
+      port:8080
+    }
+  
+  });
+}
 
-  plugins: [
-    new CleanWebpackPlugin({ // Clean all but dev subdirectory before building
-      cleanOnceBeforeBuildPatterns: ['**/*', 
-       // '!dev/**/*'      // doesn't work
-       '!dev/**'      // works
-      ],      
-    }), 
-    new RemoveStrictPlugin(),           // I have put this in to avoid IE throwing error Assignment to read-only properties is not allowed in strict mode
-    // This doesn't seem to actually be minimising the CSS!
-    new OptimizeCSSAssetsPlugin({
-      cssProcessor: require('cssnano'),
-      cssProcessorPluginOptions: {
-        preset: ['default', { discardComments: { removeAll: true } }],
-      }/*,
-      canPrint: true*/
-    }),
-    new webpack.NoEmitOnErrorsPlugin(),
-    new MiniCssExtractPlugin({
-      // Options similar to the same options in webpackOptions.output
-      // all options are optional
-      filename: '[name].[hash].css',
-      chunkFilename: '[id].css',
-      ignoreOrder: false, // Enable to remove warnings about conflicting order
-    }),  
-    new webpack.DefinePlugin({
-      'process.env': {
-        'ENV': JSON.stringify(ENV)
-      }
-    })    
-  ],
-
-  devServer: {
-    contentBase: helpers.root('.'),
-    historyApiFallback: true,
-    stats: 'minimal',
-    port:8080
-  }
-
-});
+module.exports = [
+  createConfig('var'), 
+  createConfig('amd')
+];

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -20,37 +20,20 @@ function createConfig(target){
       filename: '[name]' + filenameInsert + 'js',
       chunkFilename: '[id]' + filenameInsert + 'chunk.js',
       libraryTarget:target
-        // 'amd' // e2e n, import y
-        // 'var' // e2e y, import n
-        // 'assign' // e2e n, import n  
-        // 'global'  // e2e y, import 
     },
   
     optimization:{
-      // Enabling splitChunks seems to stop the global JSONEditor object being set
-      /*
-      splitChunks:{
-        chunks:'all'
-      },
-      */
       minimize:true
     },
   
     plugins: [
-      // new CleanWebpackPlugin({ // Clean all but dev subdirectory before building
-      //   cleanOnceBeforeBuildPatterns: ['**/*', 
-      //    // '!dev/**/*'      // doesn't work
-      //    '!dev/**'      // works
-      //   ],      
-      // }), 
       new RemoveStrictPlugin(),           // I have put this in to avoid IE throwing error Assignment to read-only properties is not allowed in strict mode
       // This doesn't seem to actually be minimising the CSS!
       new OptimizeCSSAssetsPlugin({
         cssProcessor: require('cssnano'),
         cssProcessorPluginOptions: {
           preset: ['default', { discardComments: { removeAll: true } }],
-        }/*,
-        canPrint: true*/
+        }
       }),
       new webpack.NoEmitOnErrorsPlugin(),
       new MiniCssExtractPlugin({

--- a/src/core.js
+++ b/src/core.js
@@ -842,5 +842,4 @@ assignTemplates(JSONEditor.defaults.templates);
 assignIconlibs(JSONEditor.defaults.iconlibs);
 wrapJQuery();
 
-// Webpack will now allocate this to Window
-global.JSONEditor = JSONEditor;
+window.JSONEditor = JSONEditor;

--- a/tests/unit/core.spec.js
+++ b/tests/unit/core.spec.js
@@ -31,9 +31,9 @@ describe("JSONEditor", function() {
   });  
 
   it("should create an editor", function(){
-    // expect(JSONEditor).toBeTruthy();
     var element = document.getElementById('fixture');
     console.log("Attempting to create new JSONEditor");
     var editor = new JSONEditor(element, {schema:schema });
+    expect(editor).toBeTruthy();
   });
 })


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ✔️
| Tests pass?   | ✔️/❌ - somehow 
| Fixed issues  | #519 (partially, see below)
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

The original grunt build produced a single file that could be directly included in html files (by assigning JSONEditor to the window object) or imported into another javascript file using amd.

I don't see any way to achieve this with Webpack - instead it looks like you need to create different builds for the different target formats.

I have followed [this blogpost](https://tech.trivago.com/2015/12/17/export-multiple-javascript-module-formats/) to create a jsoneditor.amd.js build in adition to the other standard ones. However this requires amd users to import the amd version as follows:
```javascript
import { JSONEditor } from '@json-editor/json-editor/dist/jsoneditor.amd.js'
```

I realise this isn't as neat as having both sets of functionality in a single distribution. I'll look into how this can be optimised.
```
: 
