### PR TITLE
Fix of #516 

### DIFF
--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -39,7 +39,7 @@ export var SelectEditor = AbstractEditor.extend({
     return Math.min(12,Math.max(longest_text/7,2));
   },
   typecast: function(value) {
-    if (this.schema.type === "boolean") return value === 'undefined' || value == undefined ? undefined : !!value;  
+    if (this.schema.type === "boolean") return value == 'undefined' || value === undefined ? undefined : !!value;  
     else if (this.schema.type === "number") return 1*value || 0;
     else if (this.schema.type === "integer") return Math.floor(value*1 || 0);
     else return ""+value;

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -39,7 +39,7 @@ export var SelectEditor = AbstractEditor.extend({
     return Math.min(12,Math.max(longest_text/7,2));
   },
   typecast: function(value) {
-    if (this.schema.type === "boolean") return !!value;
+    if (this.schema.type === "boolean") return value === 'undefined' || value == undefined ? undefined : !!value;  
     else if (this.schema.type === "number") return 1*value || 0;
     else if (this.schema.type === "integer") return Math.floor(value*1 || 0);
     else return ""+value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #516
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

Boolean values was typecast wrong when value was "undefined" or undefined (Happens when property is NOT required). Now lets the undefined value pass through. (The property value is not set if value is undefined)