### PR TITLE
bugfix for local refs url support for SPA and recursively use the describedby editor

### DIFF
--- a/docs/describedby.html
+++ b/docs/describedby.html
@@ -46,34 +46,44 @@
         disable_properties: true,
         //no_additional_properties: true,
         schema: {
-          "type": "object",
           "title": "Property for Sale",
-          "properties": {
-            "propertyName": {
-              "type": "string",
-              "title": "Property Name",
-              "description": "The name of the property being sold",
-              "minLength": 5
-            },
-            "propertyType": {
-              "type": "string",
-              "title": "Property Type",
-              "enum": ["house", "car", "yacht"]
-            },
-            "propertyTypeOptions": {
-              "type": "object",
-              "title": "Property Options",
-              "watch": {
-                  "propertyType": "propertyType"
-              },
-              "links": [{
-                "rel": "describedBy",
-                "href": "#/definitions/{{propertyType}}"
-              }]
-            }
-          },
-          "required": ["propertyName","propertyType"],
+          "$ref": "#/definitions/single",
           "definitions": {
+            "multiple": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/single"
+              }
+            },
+            "single": {
+              "id": "basic",
+              "type": "object",
+              "properties": {
+                "propertyName": {
+                  "type": "string",
+                  "title": "Property Name",
+                  "description": "The name of the property being sold",
+                  "minLength": 5
+                },
+                "propertyType": {
+                  "type": "string",
+                  "title": "Property Type",
+                  "enum": ["house", "car", "yacht","multiple"]
+                },
+                "propertyTypeOptions": {
+                  "type": ["object","array"],
+                  "title": "Property Options",
+                  "watch": {
+                    "tag": "basic.propertyType"
+                  },
+                  "links": [{
+                    "rel": "describedBy",
+                    "href": "#/definitions/{{tag}}"
+                  }]
+                }
+              },
+              "required": ["propertyName","propertyType"],
+            },
             "house": {
               "properties": {
                 "address": {

--- a/src/core.js
+++ b/src/core.js
@@ -211,7 +211,7 @@ JSONEditor.prototype = {
     this.translate = this.options.translate || JSONEditor.defaults.translate
 
     // Fetch all external refs via ajax
-    var fetchUrl = document.location.toString()
+    var fetchUrl = document.location.origin + document.location.pathname.toString()
     var fileBase = this._getFileBase()
     this._loadExternalRefs(this.schema, function () {
       self._getDefinitions(self.schema, fetchUrl + '#/definitions/')

--- a/src/editors/describedby.js
+++ b/src/editors/describedby.js
@@ -59,7 +59,7 @@ export var DescribedByEditor = AbstractEditor.extend({
     // var ref = this.template(vars);
     var ref = document.location.origin + document.location.pathname + this.template(vars)
 
-    if (!this.editors[this.refs[ref]]) {
+    if (this.jsoneditor.refs.hasOwnProperty(ref) && !this.editors[this.refs[ref]]) {
       this.buildChildEditor(ref)
     }
 
@@ -109,8 +109,8 @@ export var DescribedByEditor = AbstractEditor.extend({
     this.refs = {}
     this.editors = []
     this.currentEditor = ''
-
-    for (var i = 0; i < this.schema.links.length; i++) {
+    var i
+    for (i = 0; i < this.schema.links.length; i++) {
       if (this.schema.links[i].rel.toLowerCase() === 'describedby') {
         // this.template = new UriTemplate(this.schema.links[i].href);
         this.template = this.jsoneditor.compileTemplate(this.schema.links[i].href, this.template_engine)

--- a/src/editors/describedby.js
+++ b/src/editors/describedby.js
@@ -124,7 +124,7 @@ export var DescribedByEditor = AbstractEditor.extend({
       return '';
     }); */
 
-    this.schema.links.splice(i, 1)
+    this.schema.links = this.schema.links.slice(0, i).concat(this.schema.links.slice(i + 1))
     if (this.schema.links.length === 0) delete this.schema.links
 
     this.baseSchema = $extend({}, this.schema)

--- a/src/editors/describedby.js
+++ b/src/editors/describedby.js
@@ -126,7 +126,6 @@ export var DescribedByEditor = AbstractEditor.extend({
 
     this.schema.links = this.schema.links.slice(0, i).concat(this.schema.links.slice(i + 1))
     if (this.schema.links.length === 0) delete this.schema.links
-
     this.baseSchema = $extend({}, this.schema)
   },
   build: function () {

--- a/src/editors/describedby.js
+++ b/src/editors/describedby.js
@@ -57,7 +57,7 @@ export var DescribedByEditor = AbstractEditor.extend({
 
     // var ref = this.template.fillFromObject(vars);
     // var ref = this.template(vars);
-    var ref = document.location.toString() + this.template(vars)
+    var ref = document.location.origin + document.location.pathname + this.template(vars)
 
     if (!this.editors[this.refs[ref]]) {
       this.buildChildEditor(ref)
@@ -124,7 +124,7 @@ export var DescribedByEditor = AbstractEditor.extend({
       return '';
     }); */
 
-    this.schema.links.splice(0, 1)
+    this.schema.links.splice(i, 1)
     if (this.schema.links.length === 0) delete this.schema.links
 
     this.baseSchema = $extend({}, this.schema)

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -31,6 +31,8 @@ export var $extend = function (destination) {
       if (source[property] && $isplainobject(source[property])) {
         if (!destination.hasOwnProperty(property)) destination[property] = {}
         $extend(destination[property], source[property])
+      } else if (Array.isArray(source[property])) {
+        destination[property] = source[property].map((value) => $extend(value))
       } else {
         destination[property] = source[property]
       }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -31,8 +31,6 @@ export var $extend = function (destination) {
       if (source[property] && $isplainobject(source[property])) {
         if (!destination.hasOwnProperty(property)) destination[property] = {}
         $extend(destination[property], source[property])
-      } else if (Array.isArray(source[property])) {
-        destination[property] = source[property].map((value) => $extend(value))
       } else {
         destination[property] = source[property]
       }

--- a/src/validator.js
+++ b/src/validator.js
@@ -558,7 +558,7 @@ export const Validator = Class.extend({
           var template = this.jsoneditor.compileTemplate(href, this.jsoneditor.template)
           var ref = template(data)
 
-          schema.links.splice(m, 1)
+          schema.links = schema.links.slice(0, m).concat(schema.links.slice(m + 1))
 
           schema = $extend({}, schema, this.jsoneditor.refs[ref])
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | 
| Updated README/docs?   | ✔️
| Added CHANGELOG entry?   | ❌

1. the local refs for `describedby` editor may wook poorly if i change `window.location.hash` ( which is common for single page application) or `window.locaiton.query` after editor instance is created. 
2. the `$extend` function didn't copy a array appropriately(deeply), which leads to a problem for recursively use of `describedby` editor. for example the shema likes:
``` json

缩进量：  引号 显示控制 
格式化JSON：
{
  "title": "Property for Sale", 
  "$ref": "#/definitions/single", 
  "definitions": {
    "multiple": {
      "type": "array", 
      "items": {
        "$ref": "#/definitions/single"
      }
    }, 
    "single": {
      "id": "basic", 
      "type": "object", 
      "properties": {
        "propertyName": {
          "type": "string", 
          "title": "Property Name", 
          "description": "The name of the property being sold", 
          "minLength": 5
        }, 
        "propertyType": {
          "type": "string", 
          "title": "Property Type", 
          "enum": [
            "house", 
            "car", 
            "yacht", 
            "multiple"
          ]
        }, 
        "propertyTypeOptions": {
          "type": [
            "object", 
            "array"
          ], 
          "title": "Property Options", 
          "watch": {
            "tag": "basic.propertyType"
          }, 
          "links": [
            {
              "rel": "describedBy", 
              "href": "#/definitions/{{tag}}"
            }
          ]
        }
      }, 
      "required": [
        "propertyName", 
        "propertyType"
      ]
    }, 
    "house": {
      "properties": {
        "address": {
          "type": "string", 
          "title": "Address"
        }, 
        "rooms": {
          "type": "integer", 
          "title": "Number Of Rooms"
        }
      }
    }, 
    "car": {
      "properties": {
        "brand": {
          "type": "string", 
          "title": "Brand", 
          "enum": [
            "Audi", 
            "BMW", 
            "Chevrolet", 
            "Opel", 
            "Mitsubishi"
          ]
        }, 
        "color": {
          "type": "string", 
          "title": "Color", 
          "format": "color"
        }, 
        "year": {
          "type": "string", 
          "title": "Build Year"
        }
      }
    }, 
    "yacht": {
      "properties": {
        "name": {
          "type": "string", 
          "title": "Name"
        }, 
        "model": {
          "type": "string", 
          "title": "Model"
        }, 
        "year": {
          "type": "integer", 
          "title": "Year"
        }, 
        "yachtLength": {
          "type": "integer", 
          "title": "Length"
        }
      }
    }
  }
}
```