### PR TITLE
test case for page `array-anyof.html`

### DIFF
--- a/tests/codeceptjs/editors/array_any_of_test.js
+++ b/tests/codeceptjs/editors/array_any_of_test.js
@@ -18,22 +18,18 @@ Scenario('should show errors @optional', async (I) => {
   assert.equal(value, '{"correct":"","items":[]}');
 
   I.fillField('root[correct]', 'a');
-  I.dontSee('Value must match the pattern ^[a-zA-Z0-9_]+$.');
-  value = await I.grabValueFrom('.debug');
+  assert.equal(await I.dontSee('Value must match the pattern ^[a-zA-Z0-9_]+$.'), true, 'should show warning');
 
   I.fillField('root[correct]', 'a!');
-  I.seeInField('root[correct]', 'a!');
-  I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.');
-  value = await I.grabValueFrom('.debug');
+  assert.equal(await I.seeInField('root[correct]', 'a!'), true, 'fillField failed');
+  assert.equal(await I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.'), true, 'should show warning');
 
   I.clearField('root[correct]');
   I.seeInField('root[correct]', '');
-  I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.');
-  value = await I.grabValueFrom('.debug');
+  assert.equal(await I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.'), true, "should show warning");
 
   I.fillField('root[correct]', 'a');
   I.dontSee('Value must match the pattern ^[a-zA-Z0-9_]+$.');
-  value = await I.grabValueFrom('.debug');
 
   I.click('.json-editor-btntype-add');
   I.click('.get-value');
@@ -42,18 +38,13 @@ Scenario('should show errors @optional', async (I) => {
 
   I.fillField('root[items][0][id]', 'a');
   I.dontSee('Value must match the pattern ^[a-zA-Z0-9_]+$.');
-  value = await I.grabValueFrom('.debug');
 
   I.clearField('root[items][0][id]');
-  I.click('.get-value');
   I.seeInField('root[items][0][id]', '');
-  // todo: why this passed?
-  let r = I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.');
-  assert.equal(r, true, 'it should appear');
-  value = await I.grabValueFrom('.debug');
+  // todo still not work
+  assert.equal(await I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.'), true, 'should show warning');
 
   I.fillField('root[items][0][id]', 'a!');
-  I.click('.get-value');
   I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.');
 
 });

--- a/tests/codeceptjs/editors/array_any_of_test.js
+++ b/tests/codeceptjs/editors/array_any_of_test.js
@@ -1,0 +1,59 @@
+var assert = require('assert');
+
+Feature('anyof in array');
+
+Scenario('should have correct initial value', async (I) => {
+  I.amOnPage('array-anyof.html');
+  I.click('.get-value');
+  assert.equal(await I.grabValueFrom('.debug'), '{"correct":"","items":[]}');
+});
+
+Scenario('should show errors @optional', async (I) => {
+  I.amOnPage('array-anyof.html');
+  I.seeElement('[data-schemapath="root"]');
+  I.seeElement('[data-schemapath="root.items"]');
+
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '{"correct":"","items":[]}');
+
+  I.fillField('root[correct]', 'a');
+  I.dontSee('Value must match the pattern ^[a-zA-Z0-9_]+$.');
+  value = await I.grabValueFrom('.debug');
+
+  I.fillField('root[correct]', 'a!');
+  I.seeInField('root[correct]', 'a!');
+  I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.');
+  value = await I.grabValueFrom('.debug');
+
+  I.clearField('root[correct]');
+  I.seeInField('root[correct]', '');
+  I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.');
+  value = await I.grabValueFrom('.debug');
+
+  I.fillField('root[correct]', 'a');
+  I.dontSee('Value must match the pattern ^[a-zA-Z0-9_]+$.');
+  value = await I.grabValueFrom('.debug');
+
+  I.click('.json-editor-btntype-add');
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '{"correct":"a","items":[{"handler":"aaa","id":"","___a":""}]}');
+
+  I.fillField('root[items][0][id]', 'a');
+  I.dontSee('Value must match the pattern ^[a-zA-Z0-9_]+$.');
+  value = await I.grabValueFrom('.debug');
+
+  I.clearField('root[items][0][id]');
+  I.click('.get-value');
+  I.seeInField('root[items][0][id]', '');
+  // todo: why this passed?
+  let r = I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.');
+  assert.equal(r, true, 'it should appear');
+  value = await I.grabValueFrom('.debug');
+
+  I.fillField('root[items][0][id]', 'a!');
+  I.click('.get-value');
+  I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.');
+
+});

--- a/tests/pages/array-anyof.html
+++ b/tests/pages/array-anyof.html
@@ -17,6 +17,11 @@
     "title": "anyOf",
     "type": "object",
     "properties": {
+      "correct": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9_]+$",
+        "maxLength": 50
+      },
       "items": {
         "title": "title",
         "type": "array",
@@ -42,6 +47,7 @@
       }
     },
     "defaultProperties": [
+      "correct",
       "items"
     ],
     "definitions": {


### PR DESCRIPTION
test case for page `array-anyof.html` 

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ❌
| Fixed issues  | Test case for #459 
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌


It doesn't work correctly, i don't know why.

```
  I.clearField('root[items][0][id]');
  I.click('.get-value');
  I.seeInField('root[items][0][id]', '');
  // todo: why this passed?
  let r = I.see('Value must match the pattern ^[a-zA-Z0-9_]+$.');
  assert.equal(r, true, 'it should appear');
```
It should be failed(when i operate on browser manually it didn't display a warning).
Please help.