### PR TITLE
Fix problem with content not being visible before focus

### DIFF
--- a/README_ADDON.md
+++ b/README_ADDON.md
@@ -270,6 +270,7 @@ For configuration options, see the [SimpleMDE homepage](https://simplemde.com/).
 **Schema options:** ``options.simplemde``<br>
 **Options callback** ``JSONEditor.defaults.callbacks.simplemde``<br>
 **Required options:**  none<br>
+**Special options:** ``autorefresh`` when true, fixes problem with Chrome and editor inside Tabs<br>
 **Source:** src/editors/simplemde.js
 <br>
 


### PR DESCRIPTION
In Chrome SimpleMDE content is not visible until focus is applied. This happens when the SimpleMDE editor is hidden. (Like when placed inside Tabs)
This fix adds a custom option "autorefresh" (NO CAMELCASE) based on the code from https://codemirror.net/doc/manual.html#addon_autorefresh

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #574
| Updated README/docs?   | ❌ 
| Added CHANGELOG entry?   | ❌

Info about the "autorefresh" option have been added to `README_ADDON.md`