### PR TITLE
enumSource reorder fix, preserve value at Move Up or Down for 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,11 @@ Here are all the available options:
     <td>The default value of `format` for objects. If set to <code>table</code> for example, objects will use table layout if `format` is not specified.</td>
     <td><code>normal</code></td>
   </tr>
+  <tr>
+    <td>enum_source_value_auto_select</td>
+    <td>Preserve value at Move Up or Down.(No value is selected automatically upon deletion.)</td>
+    <td><code>true</code></td>
+  </tr>
   </tbody>
 </table>
 

--- a/docs/enumsource.html
+++ b/docs/enumsource.html
@@ -1,0 +1,68 @@
+                                                                                                                        <!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>JSON Editor enumSource Integration Example</title>
+    <script src="../dist/jsoneditor.js"></script>
+    <script type="text/javascript" src="http://cdn.jsdelivr.net/npm/jquery@latest/dist/jquery.min.js"></script>
+</head>
+
+<body>
+  <h1>Enum source sort example</h1>
+
+  <p style='margin-bottom:20px;'>
+    This example lets you edit a selection of values from an editable enumSource.
+    The selection must have unique items, which is useful to showcase an issue
+    where any changes to ordering of the enumSource array reset selections to a start value.
+  </p>
+
+  <div id='editor_holder'></div>
+  <button id='submit'>Submit (console.log)</button>
+
+  <script>
+
+    // Initialize the editor with a JSON schema
+    JSONEditor.defaults.options.enum_source_value_auto_select = true;
+    var editor = new JSONEditor(document.getElementById('editor_holder'), {
+      schema: {
+        type: "object",
+        title: "Text",
+        required: ["selectedFonts", "possibleFonts"],
+        properties: {
+          selectedFonts: {
+            type: "array",
+            format: "table",
+            uniqueItems: true,
+            items: {
+              type: "string",
+              enumSource: "possible_fonts",
+              watch: {
+                "possible_fonts": "root.possibleFonts"
+              }
+            },
+            default: ["Arial", "Times"]
+          },
+          possibleFonts: {
+            type: "array",
+            format: 'table',
+            items: {
+              type: "string"
+            },
+            default: ["Arial", "Times", "Helvetica", "Comic Sans"],
+            options: {
+              collapsed: false
+            }
+          }
+        }
+      }
+    });
+
+    // Hook up the submit button to log to the console
+    document.getElementById('submit').addEventListener('click', function () {
+      // Get the value from the editor
+      console.log(editor.getValue());
+    });
+  </script>
+</body>
+
+</html>

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -295,8 +295,9 @@ export var SelectEditor = AbstractEditor.extend({
       this.enum_display = selectTitles
       this.enum_values = selectOptions
 
-      // If the previous value is still in the new select options, stick with it
-      if (selectOptions.indexOf(prevValue) !== -1) {
+      // If the previous value is still in the new select options
+      // or if global option "enum_source_value_auto_select" is true, stick with it
+      if (selectOptions.indexOf(prevValue) !== -1 || this.jsoneditor.options.enum_source_value_auto_select) {
         this.input.value = prevValue
         this.value = prevValue
       // Otherwise, set the value to the first select option

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -297,7 +297,7 @@ export var SelectEditor = AbstractEditor.extend({
 
       // If the previous value is still in the new select options
       // or if global option "enum_source_value_auto_select" is true, stick with it
-      if (selectOptions.indexOf(prevValue) !== -1 && !this.jsoneditor.options.enum_source_value_auto_select) {
+      if (selectOptions.indexOf(prevValue) !== -1 || this.jsoneditor.options.enum_source_value_auto_select !== false) {
         this.input.value = prevValue
         this.value = prevValue
       // Otherwise, set the value to the first select option

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -297,7 +297,7 @@ export var SelectEditor = AbstractEditor.extend({
 
       // If the previous value is still in the new select options
       // or if global option "enum_source_value_auto_select" is true, stick with it
-      if (selectOptions.indexOf(prevValue) !== -1 || this.jsoneditor.options.enum_source_value_auto_select) {
+      if (selectOptions.indexOf(prevValue) !== -1 && !this.jsoneditor.options.enum_source_value_auto_select) {
         this.input.value = prevValue
         this.value = prevValue
       // Otherwise, set the value to the first select option


### PR DESCRIPTION
#187 ported to 2.x version. 
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ✔️
| Added CHANGELOG entry?   | ❌

@schmunk42 I noticed an odd behavior when using the provided example. When the new option `enum_source_value_auto_select` is NOT ENABLED (Default behavior) and you move an item from `possibleFonts` up/down, you get duplicate entries in `selectedFonts`

So should we enable the new option by default?
