### PR TITLE
Fix of #580 - DescribedBy Editor doesn't validate referenced properties (they are always valid)

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -556,7 +556,7 @@ export const Validator = Class.extend({
           // var template = new UriTemplate(href); //preprocessURI(href));
           // var ref = template.fillFromObject(data);
           var template = this.jsoneditor.compileTemplate(href, this.jsoneditor.template)
-          var ref = template(data)
+          var ref = document.location.origin + document.location.pathname + template(data)
 
           schema.links = schema.links.slice(0, m).concat(schema.links.slice(m + 1))
 


### PR DESCRIPTION
Fix of #580 - DescribedBy Editor doesn't validate referenced properties (they are always valid)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️#580
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
