### PR TITLE
Un-updated Themes and Iconlibs removed (commented out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Current 2.0.0-dev
 
+  - Removed Themes and IconSets that have not been updated to 2.0 format.
   - Fix of #618 - links are placed AFTER the description. Now places the link BEFORE description (if available) or at bottom of container
   - Changes to Vallilla Colorpicker editor.
    * Added support for 'setValue'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Current 2.0.0-dev
-
+  - Fix of #643 - Allow use of themes not compiled directly into the build
   - Removed Themes and IconSets that have not been updated to 2.0 format.
   - Fix of #618 - links are placed AFTER the description. Now places the link BEFORE description (if available) or at bottom of container
   - Changes to Vallilla Colorpicker editor.

--- a/src/core.js
+++ b/src/core.js
@@ -5,6 +5,7 @@ import { getDefaults } from './defaults'
 import { Validator } from './validator'
 import { $extend, $each } from './utilities'
 
+import { AbstractTheme } from './theme'
 import { htmlTheme } from './themes/html'
 // import { bootstrap2Theme } from './themes/bootstrap2'
 // import { bootstrap3Theme } from './themes/bootstrap3'
@@ -812,6 +813,7 @@ JSONEditor.prototype = {
 JSONEditor.defaults = getDefaults()
 assignThemes(JSONEditor.defaults.themes)
 JSONEditor.AbstractEditor = AbstractEditor
+JSONEditor.AbstractTheme = AbstractTheme
 assignDefaultEditors(JSONEditor.defaults.editors)
 assignTemplates(JSONEditor.defaults.templates)
 assignIconlibs(JSONEditor.defaults.iconlibs)

--- a/src/core.js
+++ b/src/core.js
@@ -6,13 +6,13 @@ import { Validator } from './validator'
 import { $extend, $each } from './utilities'
 
 import { htmlTheme } from './themes/html'
-import { bootstrap2Theme } from './themes/bootstrap2'
-import { bootstrap3Theme } from './themes/bootstrap3'
+// import { bootstrap2Theme } from './themes/bootstrap2'
+// import { bootstrap3Theme } from './themes/bootstrap3'
 import { bootstrap4Theme } from './themes/bootstrap4'
-import { foundationTheme, foundation3Theme, foundation4Theme, foundation5Theme, foundation6Theme } from './themes/foundation'
+// import { foundationTheme, foundation3Theme, foundation4Theme, foundation5Theme, foundation6Theme } from './themes/foundation'
 import { jqueryuiTheme } from './themes/jqueryui'
 import { barebonesTheme } from './themes/barebones'
-import { materializeTheme } from './themes/materialize'
+// import { materializeTheme } from './themes/materialize'
 import { spectreTheme } from './themes/spectre'
 import { tailwindTheme } from './themes/tailwind'
 
@@ -64,43 +64,43 @@ import { mustacheTemplate } from './templates/mustache'
 import { swigTemplate } from './templates/swig'
 import { underscoreTemplate } from './templates/underscore'
 
-import { bootstrap2Iconlib } from './iconlibs/bootstrap2'
-import { bootstrap3Iconlib } from './iconlibs/bootstrap3'
+// import { bootstrap2Iconlib } from './iconlibs/bootstrap2'
+// import { bootstrap3Iconlib } from './iconlibs/bootstrap3'
 import { fontawesome3Iconlib } from './iconlibs/fontawesome3'
 import { fontawesome4Iconlib } from './iconlibs/fontawesome4'
 import { fontawesome5Iconlib } from './iconlibs/fontawesome5'
-import { foundation2Iconlib } from './iconlibs/foundation2'
-import { foundation3Iconlib } from './iconlibs/foundation3'
+// import { foundation2Iconlib } from './iconlibs/foundation2'
+// import { foundation3Iconlib } from './iconlibs/foundation3'
 import { jqueryuiIconlib } from './iconlibs/jqueryui'
-import { materialiconsIconlib } from './iconlibs/materialicons'
+// import { materialiconsIconlib } from './iconlibs/materialicons'
 import { spectreIconlib } from './iconlibs/spectre'
 
 var assignIconlibs = function (iconlibs) {
-  iconlibs.bootstrap2 = bootstrap2Iconlib
-  iconlibs.bootstrap3 = bootstrap3Iconlib
+  // iconlibs.bootstrap2 = bootstrap2Iconlib
+  // iconlibs.bootstrap3 = bootstrap3Iconlib
   iconlibs.fontawesome3 = fontawesome3Iconlib
   iconlibs.fontawesome4 = fontawesome4Iconlib
   iconlibs.fontawesome5 = fontawesome5Iconlib
-  iconlibs.foundation2 = foundation2Iconlib
-  iconlibs.foundation3 = foundation3Iconlib
+  // iconlibs.foundation2 = foundation2Iconlib
+  // iconlibs.foundation3 = foundation3Iconlib
   iconlibs.jqueryui = jqueryuiIconlib
-  iconlibs.materialicons = materialiconsIconlib
+  // iconlibs.materialicons = materialiconsIconlib
   iconlibs.spectre = spectreIconlib
 }
 
 var assignThemes = function (themes) {
   themes.html = htmlTheme
-  themes.bootstrap2 = bootstrap2Theme
-  themes.bootstrap3 = bootstrap3Theme
+  // themes.bootstrap2 = bootstrap2Theme
+  // themes.bootstrap3 = bootstrap3Theme
   themes.bootstrap4 = bootstrap4Theme
-  themes.foundation = foundationTheme
-  themes.foundation3 = foundation3Theme
-  themes.foundation4 = foundation4Theme
-  themes.foundation5 = foundation5Theme
-  themes.foundation6 = foundation6Theme
+  // themes.foundation = foundationTheme
+  // themes.foundation3 = foundation3Theme
+  // themes.foundation4 = foundation4Theme
+  // themes.foundation5 = foundation5Theme
+  // themes.foundation6 = foundation6Theme
   themes.jqueryui = jqueryuiTheme
   themes.barebones = barebonesTheme
-  themes.materialize = materializeTheme
+  // themes.materialize = materializeTheme
   themes.spectre = spectreTheme
   themes.tailwind = tailwindTheme
 }

--- a/tests/codeceptjs/editors/object_test.js
+++ b/tests/codeceptjs/editors/object_test.js
@@ -36,17 +36,17 @@ Scenario('grid-strict rows and columns', (I) => {
   I.seeElement('.col-md-10');
   I.seeElement('.col-md-11');
   I.seeElement('.col-md-12');
-  I.seeElement('.col-md-offset-1');
-  I.seeElement('.col-md-offset-2');
-  I.seeElement('.col-md-offset-3');
-  I.seeElement('.col-md-offset-4');
-  I.seeElement('.col-md-offset-5');
-  I.seeElement('.col-md-offset-6');
-  I.seeElement('.col-md-offset-7');
-  I.seeElement('.col-md-offset-8');
-  I.seeElement('.col-md-offset-9');
-  I.seeElement('.col-md-offset-10');
-  I.seeElement('.col-md-offset-11');
+  I.seeElement('.col-md-1.offset-md-1');
+  I.seeElement('.col-md-1.offset-md-2');
+  I.seeElement('.col-md-1.offset-md-3');
+  I.seeElement('.col-md-1.offset-md-4');
+  I.seeElement('.col-md-1.offset-md-5');
+  I.seeElement('.col-md-1.offset-md-6');
+  I.seeElement('.col-md-1.offset-md-7');
+  I.seeElement('.col-md-1.offset-md-8');
+  I.seeElement('.col-md-1.offset-md-9');
+  I.seeElement('.col-md-1.offset-md-10');
+  I.seeElement('.col-md-1.offset-md-11');
 });
 
 Scenario('grid rows and columns', (I) => {

--- a/tests/pages/grid-strict.html
+++ b/tests/pages/grid-strict.html
@@ -252,7 +252,7 @@
     };
 
     if(typeof mapping[theme] === 'undefined') {
-      theme = 'bootstrap3';
+      theme = 'bootstrap4';
       document.getElementById('theme_switcher').value = theme;
     }
 

--- a/tests/pages/grid-strict.html
+++ b/tests/pages/grid-strict.html
@@ -300,7 +300,7 @@
   window.addEventListener('load',function() {
     editor = new JSONEditor(container, {
       schema: schema,
-      theme: 'bootstrap3'
+      theme: 'bootstrap4'
     });
     setTheme(this.value);
   });

--- a/tests/pages/grid.html
+++ b/tests/pages/grid.html
@@ -270,7 +270,7 @@
   window.addEventListener('load',function() {
     editor = new JSONEditor(container, {
       schema: schema,
-      theme: 'bootstrap3'
+      theme: 'bootstrap4'
     });
     setTheme(this.value);
   });

--- a/tests/pages/grid.html
+++ b/tests/pages/grid.html
@@ -222,7 +222,7 @@
     };
 
     if(typeof mapping[theme] === 'undefined') {
-      theme = 'bootstrap3';
+      theme = 'bootstrap4';
       document.getElementById('theme_switcher').value = theme;
     }
 

--- a/tests/pages/object-required-properties.html
+++ b/tests/pages/object-required-properties.html
@@ -195,7 +195,7 @@
   initJsonEditor = function () {
     editor = new JSONEditor(container, {
       schema: schema,
-      theme: 'bootstrap3',
+      theme: 'bootstrap4',
       show_opt_in: true,
       // display_required_only: true
     });


### PR DESCRIPTION
- Removed (commented out) Bootstrap 2/3, Foundation and Materialize Themes.
- Removed (commented out) Bootstrap 2/3, Foundation and Materialize Iconsets.

Files have **NOT** been removed from `src/`, so it's possible to include them again if needed.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #643 
| Updated README/docs?   | ✔️
| Added CHANGELOG entry?   | ✔️

**Size differences:**
unminified: 516kb vs **460kb**
    minified: 253kb vs **226kb**

Not sure if we should merge this yet. Was just created to see how much smaller the lib would be without them.