### PR TITLE
filterable property list of object editor

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -627,6 +627,15 @@ export var ObjectEditor = AbstractEditor.extend({
           self.onChange(true)
         }
       })
+      this.addproperty_input.addEventListener('input', function (e) {
+        e.target.previousSibling.childNodes.forEach(function (value) {
+          if (value.innerText.indexOf(e.target.value) >= 0) {
+            value.style.display = ''
+          } else {
+            value.style.display = 'none'
+          }
+        })
+      })
       this.addproperty_holder.appendChild(this.addproperty_list)
       this.addproperty_holder.appendChild(this.addproperty_input)
       this.addproperty_holder.appendChild(this.addproperty_add)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    |❌
| New feature?  | ✔️
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

 The property list in object editor can be filterable，for example, 
1. the origin property list looks like ![origin](http://chuantu.xyz/t6/702/1572427470x3703728804.png)
2. when I input some letters the property list become ![origin](http://chuantu.xyz/t6/702/1572427616x3661913030.png)

This feature may make it fast and convenience to locate a property if the editor has a large amount of available properties.