### PR TITLE
Uploadrefactor2

### DIFF
--- a/src/editors/upload.js
+++ b/src/editors/upload.js
@@ -47,20 +47,26 @@ export var UploadEditor = AbstractEditor.extend({
     this.control = this.theme.getFormControl(this.label, this.uploader || this.input, this.preview)
     this.container.appendChild(this.control)
 
+    // Any special formatting that needs to happen after the input is added to the dom
     window.requestAnimationFrame(function () {
-      if (self.value) {
-        var img = document.createElement('img')
-        img.style.maxWidth = '100%'
-        img.style.maxHeight = '100px'
-        img.onload = function (event) {
-          self.preview.appendChild(img)
-        }
-        img.onerror = function (error) {
-          console.error('upload error', error)
-        }
-        img.src = self.container.querySelector('a').href
-      }
+      self.afterInputReady()
     })
+  },
+  afterInputReady: function () {
+    var self = this
+    if (self.value) {
+      var img = document.createElement('img')
+      img.style.maxWidth = '100%'
+      img.style.maxHeight = '100px'
+      img.onload = function (event) {
+        self.preview.appendChild(img)
+      }
+      img.onerror = function (error) {
+        console.error('upload error', error)
+      }
+      img.src = self.container.querySelector('a').href
+    }
+    self.theme.afterInputReady(self.input)
   },
   refreshPreview: function () {
     if (this.last_preview === this.preview_value) return

--- a/src/editors/upload.js
+++ b/src/editors/upload.js
@@ -1,4 +1,5 @@
 import { AbstractEditor } from '../editor'
+import { $extend } from '../utilities'
 
 export var UploadEditor = AbstractEditor.extend({
 
@@ -8,6 +9,11 @@ export var UploadEditor = AbstractEditor.extend({
   build: function () {
     var self = this
     this.title = this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
+
+    // Editor options
+    var options = this.expandCallbacks('fileupload', $extend({}, {
+      'title': 'Browse'
+    }, this.defaults.options.fileupload || {}, this.options.fileupload || {}))
 
     // Input that holds the base64 string
     this.input = this.theme.getFormInputField('hidden')
@@ -19,14 +25,28 @@ export var UploadEditor = AbstractEditor.extend({
 
       // File uploader
       this.uploader = this.theme.getFormInputField('file')
+      this.uploader.style.display = 'none'
 
+      // Browse button
+      this.browseButton = this.theme.getFormButton(options.title, null, options.title)
+      // this.container.appendChild(this.browseButton)
+
+      // Display field
+      this.fileDisplay = this.theme.getFormInputField('input')
+      this.fileDisplay.setAttribute('readonly', true)
+      this.fileDisplay.value = 'No file selected.'
+      // this.container.appendChild(this.fileDisplay)
+
+      this.container.appendChild(this.theme.getInputGroup(this.fileDisplay, [this.browseButton]))
+
+      // Triggered after file have been selected
       this.uploader.addEventListener('change', function (e) {
         e.preventDefault()
         e.stopPropagation()
 
         if (this.files && this.files.length) {
-          // eslint-disable-next-line no-undef
-          var fr = new FileReader()
+          self.fileDisplay.value = this.files.length > 1 ? this.files.length + ' files.' : this.files[0].name
+          var fr = new window.FileReader()
           fr.onload = function (evt) {
             self.preview_value = evt.target.result
             self.refreshPreview()
@@ -35,6 +55,15 @@ export var UploadEditor = AbstractEditor.extend({
           }
           fr.readAsDataURL(this.files[0])
         }
+      })
+
+      // Pass click to this.uploader element
+      this.browseButton.addEventListener('click', function (e) {
+        self.uploader.dispatchEvent(new window.MouseEvent('click', {
+          'view': window,
+          'bubbles': true,
+          'cancelable': false
+        }))
       })
     }
 


### PR DESCRIPTION
The original browser file field is hidden and replaced with custom button/display field. Click on button triggers the hidden input field, so functionality is identical to before. (But now you can style the output in Themes)

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | (✔️)
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

**Output using the Bootstrap 4 Theme;**
![image](https://user-images.githubusercontent.com/478711/67955449-e8543180-fbf2-11e9-8fa0-e038cc7a5890.png)
