### PR TITLE
Add importable module as build target

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -62,5 +62,6 @@ function createConfig (target) {
 
 module.exports = [
   createConfig('var'),
-  createConfig('amd')
+  createConfig('amd'),
+  createConfig('commonjs2')
 ]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JSON Schema based editor",
   "version": "2.0.0-alpha.0",
   "main": "dist/jsoneditor.js",
+  "module": "dist/jsoneditor.commonjs2.js",
   "author": {
     "name": "Jeremy Dorn",
     "email": "jeremy@jeremydorn.com",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

importing JSONEditor was not possible anymore.

With commonjs2 build target it is possible to import it using named import:
import { JSONEditor } from '@json-editor/json-editor'

