### PR TITLE
Update colorpicker.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Current 2.0.0-dev
-
+  - Changes to Vallilla Colorpicker editor.
+   * Added support for 'setValue'
+   * Added better enable/disable methods.
+   * Removed "onChange" function from list of required options so it can be overidden using schema options.
+   * Changed the update method (Otherwise buttons have no meaning). Now updating is done in "onDone" function, except if inline element. Then updating is done using "onChange" function.
   - Improved IMask support for `Date`, `Number`, `IMask.MaskedEnum`, `IMask.MaskedRange` and regular expression masks. #591
   - Added support for recursive callback options.
 

--- a/src/editors/colorpicker.js
+++ b/src/editors/colorpicker.js
@@ -9,6 +9,13 @@ import { StringEditor } from './string'
 import { $extend } from '../utilities'
 
 export var ColorEditor = StringEditor.extend({
+  setValue: function (value, initial, fromTemplate) {
+    var res = this._super(value, initial, fromTemplate)
+    if (this.picker_instance && this.picker_instance.domElement && res && res.changed) {
+      this.picker_instance.setColor(res.value, true)
+    }
+    return res
+  },
   afterInputReady: function () {
     this._super()
     this.createPicker(true)

--- a/src/editors/colorpicker.js
+++ b/src/editors/colorpicker.js
@@ -15,11 +15,27 @@ export var ColorEditor = StringEditor.extend({
   },
   disable: function () {
     this._super()
-    this.createPicker(false)
+    if (this.picker_instance && this.picker_instance.domElement) {
+      // Disable picker cursor dragging
+      this.picker_instance.domElement.style.pointerEvents = 'none'
+      // Disable picker buttons
+      var buttons = this.picker_instance.domElement.querySelectorAll('button')
+      for (var i = 0; i < buttons.length; i++) {
+        buttons[i].disabled = true
+      }
+    }
   },
   enable: function () {
     this._super()
-    this.createPicker(true)
+    if (this.picker_instance && this.picker_instance.domElement) {
+      // Enable picker cursor dragging
+      this.picker_instance.domElement.style.pointerEvents = 'auto'
+      // Enable picker buttons
+      var buttons = this.picker_instance.domElement.querySelectorAll('button')
+      for (var i = 0; i < buttons.length; i++) {
+        buttons[i].disabled = false
+      }
+    }
   },
   destroy: function () {
     this.createPicker(false)
@@ -36,13 +52,17 @@ export var ColorEditor = StringEditor.extend({
           color: this.value,
           popup: 'bottom' // show in the bottom
         }, this.defaults.options.colorpicker || {}, this.options.colorpicker || {}, {
-          parent: this.container,
-          onChange: function (color) {
-            const format = this.settings.editorFormat
-            const isAlpha = this.settings.alpha
-            self.setValue(format === 'hex' ? (isAlpha ? color.hex : color.hex.slice(0, 7)) : color[format + (isAlpha ? 'a' : '') + 'String'])
-          }
+          parent: this.container
         }))
+
+        var updateHandler = function (color) {
+          const format = this.settings.editorFormat
+          const isAlpha = this.settings.alpha
+          self.setValue(format === 'hex' ? (isAlpha ? color.hex : color.hex.slice(0, 7)) : color[format + (isAlpha ? 'a' : '') + 'String'])
+        }
+        if (!options.popup && typeof options.onChange !== 'function') options.onChange = updateHandler
+        else if (options.popup && typeof options.onDone !== 'function') options.onDone = updateHandler
+
         this.input.type = 'text'
         this.picker_instance = new window.Picker(options)
         // this.picker_instance.openHandler()

--- a/src/editors/colorpicker.js
+++ b/src/editors/colorpicker.js
@@ -9,12 +9,18 @@ import { StringEditor } from './string'
 import { $extend } from '../utilities'
 
 export var ColorEditor = StringEditor.extend({
+  postBuild: function () {
+    if (window.Picker) this.input.type = 'text'
+  },
   setValue: function (value, initial, fromTemplate) {
     var res = this._super(value, initial, fromTemplate)
     if (this.picker_instance && this.picker_instance.domElement && res && res.changed) {
       this.picker_instance.setColor(res.value, true)
     }
     return res
+  },
+  getNumColumns: function () {
+    return 2
   },
   afterInputReady: function () {
     this._super()
@@ -70,7 +76,6 @@ export var ColorEditor = StringEditor.extend({
         if (!options.popup && typeof options.onChange !== 'function') options.onChange = updateHandler
         else if (options.popup && typeof options.onDone !== 'function') options.onDone = updateHandler
 
-        this.input.type = 'text'
         this.picker_instance = new window.Picker(options)
         // this.picker_instance.openHandler()
         if (!options.popup) { // use inline colorPicker

--- a/tests/codeceptjs/editors/colorpicker_test.js
+++ b/tests/codeceptjs/editors/colorpicker_test.js
@@ -18,7 +18,8 @@ Scenario('test ColorPicker Editor  using vanilla-picker', async (I) => {
   await I.dragAndDrop('[data-schemapath="root.colorpicker"] .picker_wrapper .picker_sl .picker_selector', '[data-schemapath="root.colorpicker"] .picker_wrapper .picker_sl')
   await I.dragAndDrop('[data-schemapath="root.colorpicker"] .picker_wrapper .picker_hue .picker_selector', '[data-schemapath="root.colorpicker"] .picker_wrapper .picker_hue')
   await I.dragAndDrop('[data-schemapath="root.colorpicker"] .picker_wrapper .picker_alpha .picker_selector', '[data-schemapath="root.colorpicker"] .picker_wrapper .picker_alpha')
-  I.click('.get-value');
+  I.click('.picker_done button')
+  // I.click('.get-value');
   I.click('.get-value');
   const color = await I.grabValueFrom('.debug')
   const reg = /\{"colorpicker":"rgba\(6\d,19\d,19\d,0.5\d*\)"\}/;

--- a/tests/pages/colorpicker-use-vanilla-picker.html
+++ b/tests/pages/colorpicker-use-vanilla-picker.html
@@ -25,7 +25,7 @@
       "colorpicker": {
         "type": "string",
         "format": "color",
-        "default": "#000000",
+        "default": "rgba(0,0,0,1)",
         "options": {
           "colorpicker": {
             "alpha": true,


### PR DESCRIPTION
- Added support for 'setValue'   
- Added better enable/disable methods.
- Removed "onChange" function from list of required options so it can be overidden using schema options.
- Changed the update method (Otherwise buttons have no meaning). Now updating is done in "onDone" function, except if inline element. Then updating is done using "onChange" function.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks backward-compatibility?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️
