### PR TITLE
Split core.js. Add schemaloader.js module.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,38 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+      "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^4.2.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.2.tgz",
+      "integrity": "sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==",
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -5694,6 +5726,11 @@
         "array-includes": "^3.0.3"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
+    },
     "karma": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-4.2.0.tgz",
@@ -5968,6 +6005,11 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
@@ -6091,6 +6133,14 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
       "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
       "dev": true
+    },
+    "lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -6935,6 +6985,34 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
+      "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^5.0.1",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -9471,6 +9549,40 @@
         }
       }
     },
+    "sinon": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.1.tgz",
+      "integrity": "sha512-E+tWr3acRdoe1nXbHMu86SSqA1WGM7Yw3jZRLvlCMnXwTHP8lgFFVn5BnKnF26uc5SfZ3D7pA9sN7S3Y2jG4Ew==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/samsam": "^4.2.2",
+        "diff": "^4.0.2",
+        "lolex": "^5.1.2",
+        "nise": "^3.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -10880,6 +10992,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "remove-strict-webpack-plugin": "^0.1.2",
     "requirejs": "^2.3.6",
     "sceditor": "^2.1.3",
+    "sinon": "^8.1.1",
     "standard": "^11.0.1",
     "style-loader": "^1.0.0",
     "webpack": "^4.39.1",

--- a/src/core.js
+++ b/src/core.js
@@ -208,8 +208,7 @@ JSONEditor.prototype = {
 
     // Fetch all external refs via ajax
     var fetchUrl = document.location.origin + document.location.pathname.toString()
-    var refs = self.options.refs || {}
-    var loader = new SchemaLoader(refs, self.options)
+    var loader = new SchemaLoader(self.options)
     var location = document.location.toString()
 
     this.expandSchema = function (schema, fileBase) { return loader.expandSchema(schema, fileBase) }

--- a/src/core.js
+++ b/src/core.js
@@ -3,6 +3,7 @@ import './styles/starrating.css'
 
 import { getDefaults } from './defaults'
 import { Validator } from './validator'
+import { SchemaLoader } from './schemaloader'
 import { $extend, $each } from './utilities'
 
 import { AbstractTheme } from './theme'
@@ -53,7 +54,7 @@ import { StringEditor } from './editors/string'
 import { TableEditor } from './editors/table'
 import { UploadEditor } from './editors/upload'
 import { UuidEditor } from './editors/uuid'
-import {ColorEditor} from './editors/colorpicker'
+import { ColorEditor } from './editors/colorpicker'
 
 import { defaultTemplate } from './templates/default'
 import { ejsTemplate } from './templates/ejs'
@@ -179,10 +180,6 @@ JSONEditor.prototype = {
 
     this.ready = false
     this.copyClipboard = null
-    // full references info
-    this.refs_with_info = {}
-    this.refs_prefix = '#/counter/'
-    this.refs_counter = 1
 
     var themeName = this.options.theme || JSONEditor.defaults.theme
     var themeClass = JSONEditor.defaults.themes[themeName]
@@ -196,7 +193,6 @@ JSONEditor.prototype = {
     if (!this.theme.options.disable_theme_rules) this.addNewStyleRules(themeName, this.theme.rules)
 
     this.template = this.options.template
-    this.refs = this.options.refs || {}
     this.uuid = 0
     this.__data = {}
 
@@ -212,10 +208,15 @@ JSONEditor.prototype = {
 
     // Fetch all external refs via ajax
     var fetchUrl = document.location.origin + document.location.pathname.toString()
-    var fileBase = this._getFileBase()
-    this._loadExternalRefs(this.schema, function () {
-      self._getDefinitions(self.schema, fetchUrl + '#/definitions/')
+    var refs = self.options.refs || {}
+    var loader = new SchemaLoader(refs, self.options)
+    var location = document.location.toString()
 
+    this.expandSchema = function (schema, fileBase) { return loader.expandSchema(schema, fileBase) }
+    this.expandRefs = function (schema, fileBase) { return loader.expandRefs(schema, fileBase) }
+    this.refs = loader.refs
+
+    loader.load(self.options.schema, function (schema) {
       // Validator options
       var validatorOptions = {}
       if (self.options.custom_validators) {
@@ -223,8 +224,6 @@ JSONEditor.prototype = {
       }
       self.validator = new Validator(self, null, validatorOptions, JSONEditor.defaults)
 
-      // Create the root editor
-      var schema = self.expandRefs(self.schema)
       var editorClass = self.getEditorClass(schema)
       self.root = self.createEditor(editorClass, {
         jsoneditor: self,
@@ -252,7 +251,7 @@ JSONEditor.prototype = {
         self.trigger('ready')
         self.trigger('change')
       })
-    }, fetchUrl, fileBase)
+    }, fetchUrl, location)
   },
 
   getValue: function () {
@@ -491,295 +490,6 @@ JSONEditor.prototype = {
   },
   disable: function () {
     this.root.disable()
-  },
-  _getDefinitions: function (schema, path) {
-    if (schema.definitions) {
-      for (var i in schema.definitions) {
-        if (!schema.definitions.hasOwnProperty(i)) continue
-        this.refs[path + i] = schema.definitions[i]
-        if (schema.definitions[i].definitions) {
-          this._getDefinitions(schema.definitions[i], path + i + '/definitions/')
-        }
-      }
-    }
-  },
-  _getExternalRefs: function (schema, fetchUrl) {
-    var refs = {}
-    var mergeRefs = function (newrefs) {
-      for (var i in newrefs) {
-        if (newrefs.hasOwnProperty(i)) {
-          refs[i] = true
-        }
-      }
-    }
-
-    if (schema.$ref && typeof schema.$ref !== 'object') {
-      var refCounter = this.refs_prefix + this.refs_counter++
-      if (schema.$ref.substr(0, 1) !== '#' && !this.refs[schema.$ref]) {
-        refs[schema.$ref] = true
-      }
-      this.refs_with_info[refCounter] = { fetchUrl: fetchUrl, '$ref': schema.$ref }
-      schema.$ref = refCounter
-    }
-
-    for (var i in schema) {
-      if (!schema.hasOwnProperty(i)) continue
-      if (!schema[i] || typeof schema[i] !== 'object') continue
-      if (Array.isArray(schema[i])) {
-        for (var j = 0; j < schema[i].length; j++) {
-          if (schema[i][j] && typeof schema[i][j] === 'object') {
-            mergeRefs(this._getExternalRefs(schema[i][j], fetchUrl))
-          }
-        }
-      } else {
-        mergeRefs(this._getExternalRefs(schema[i], fetchUrl))
-      }
-    }
-    return refs
-  },
-  _getFileBase: function () {
-    var fileBase = this.options.ajaxBase
-    if (typeof fileBase === 'undefined') {
-      fileBase = this._getFileBaseFromFileLocation(document.location.toString())
-    }
-    return fileBase
-  },
-  _getFileBaseFromFileLocation: function (fileLocationString) {
-    var pathItems = fileLocationString.split('/')
-    pathItems.pop()
-    return pathItems.join('/') + '/'
-  },
-  _loadExternalRefs: function (schema, callback, fetchUrl, fileBase) {
-    var self = this
-    var refs = this._getExternalRefs(schema, fetchUrl)
-    var done = 0; var waiting = 0; var callbackFired = false
-
-    $each(refs, function (url) {
-      if (self.refs[url]) return
-      if (!self.options.ajax) throw new Error('Must set ajax option to true to load external ref ' + url)
-      self.refs[url] = 'loading'
-      waiting++
-
-      var fetchUrl = url
-      if (fileBase !== url.substr(0, fileBase.length) && url.substr(0, 4) !== 'http' && url.substr(0, 1) !== '/') fetchUrl = fileBase + url
-
-      // eslint-disable-next-line no-undef
-      var r = new XMLHttpRequest()
-      r.overrideMimeType('application/json')
-      r.open('GET', fetchUrl, true)
-      if (self.options.ajaxCredentials) r.withCredentials = self.options.ajaxCredentials
-      r.onreadystatechange = function () {
-        if (r.readyState !== 4) return
-        // Request succeeded
-        if (r.status === 200) {
-          var response
-          try {
-            response = JSON.parse(r.responseText)
-          } catch (e) {
-            window.console.log(e)
-            throw new Error('Failed to parse external ref ' + fetchUrl)
-          }
-          if (!(typeof response === 'boolean' || typeof response === 'object') || response === null || Array.isArray(response)) {
-            throw new Error('External ref does not contain a valid schema - ' + fetchUrl)
-          }
-
-          self.refs[url] = response
-          var fileBase = self._getFileBaseFromFileLocation(fetchUrl)
-          self._getDefinitions(response, fetchUrl + '#/definitions/')
-          self._loadExternalRefs(response, function () {
-            done++
-            if (done >= waiting && !callbackFired) {
-              callbackFired = true
-              callback()
-            }
-          }, fetchUrl, fileBase)
-        } else {
-        // Request failed
-          window.console.log(r)
-          throw new Error('Failed to fetch ref via ajax- ' + url)
-        }
-      }
-      r.send()
-    })
-
-    if (!waiting) {
-      callback()
-    }
-  },
-  expandRefs: function (schema, recurseAllOf) {
-    schema = $extend({}, schema)
-
-    while (schema.$ref) {
-      var refObj = this.refs_with_info[schema.$ref]
-      delete schema.$ref
-      var fetchUrl = ''
-      if (refObj.$ref.startsWith('#')) {
-        fetchUrl = refObj.fetchUrl
-      }
-      var ref = fetchUrl + refObj.$ref
-      if (!this.refs[ref]) ref = fetchUrl + decodeURIComponent(refObj.$ref)
-      if (!this.refs[ref]) { // if reference not found
-        console.warn("reference:'" + ref + "' not found!")
-        break
-      }
-      if (recurseAllOf) {
-        if (this.refs[ref].hasOwnProperty('allOf')) {
-          var allOf = this.refs[ref].allOf
-          for (var i = 0; i < allOf.length; i++) {
-            allOf[i] = this.expandRefs(allOf[i], true)
-          }
-        }
-      }
-      schema = this.extendSchemas(schema, this.expandSchema(this.refs[ref]))
-      // schema = this.extendSchemas(schema, $extend({}, this.refs[ref]))
-    }
-    return schema
-  },
-  expandSchema: function (schema, fileBase) {
-    var self = this
-    var extended = $extend({}, schema)
-    var i
-
-    // Version 3 `type`
-    if (typeof schema.type === 'object') {
-      // Array of types
-      if (Array.isArray(schema.type)) {
-        $each(schema.type, function (key, value) {
-          // Schema
-          if (typeof value === 'object') {
-            schema.type[key] = self.expandSchema(value)
-          }
-        })
-      } else {
-      // Schema
-        schema.type = self.expandSchema(schema.type)
-      }
-    }
-    // Version 3 `disallow`
-    if (typeof schema.disallow === 'object') {
-      // Array of types
-      if (Array.isArray(schema.disallow)) {
-        $each(schema.disallow, function (key, value) {
-          // Schema
-          if (typeof value === 'object') {
-            schema.disallow[key] = self.expandSchema(value)
-          }
-        })
-      } else {
-        // Schema
-        schema.disallow = self.expandSchema(schema.disallow)
-      }
-    }
-    // Version 4 `anyOf`
-    if (schema.anyOf) {
-      $each(schema.anyOf, function (key, value) {
-        schema.anyOf[key] = self.expandSchema(value)
-      })
-    }
-    // Version 4 `dependencies` (schema dependencies)
-    if (schema.dependencies) {
-      $each(schema.dependencies, function (key, value) {
-        if (typeof value === 'object' && !(Array.isArray(value))) {
-          schema.dependencies[key] = self.expandSchema(value)
-        }
-      })
-    }
-    // Version 4 `not`
-    if (schema.not) {
-      schema.not = this.expandSchema(schema.not)
-    }
-
-    // allOf schemas should be merged into the parent
-    if (schema.allOf) {
-      for (i = 0; i < schema.allOf.length; i++) {
-        schema.allOf[i] = this.expandRefs(schema.allOf[i], true)
-        extended = this.extendSchemas(extended, this.expandSchema(schema.allOf[i]))
-      }
-      delete extended.allOf
-    }
-    // extends schemas should be merged into parent
-    if (schema['extends']) {
-      // If extends is a schema
-      if (!(Array.isArray(schema['extends']))) {
-        extended = this.extendSchemas(extended, this.expandSchema(schema['extends']))
-      } else {
-      // If extends is an array of schemas
-        for (i = 0; i < schema['extends'].length; i++) {
-          extended = this.extendSchemas(extended, this.expandSchema(schema['extends'][i]))
-        }
-      }
-      delete extended['extends']
-    }
-    // parent should be merged into oneOf schemas
-    if (schema.oneOf) {
-      var tmp = $extend({}, extended)
-      delete tmp.oneOf
-      for (i = 0; i < schema.oneOf.length; i++) {
-        extended.oneOf[i] = this.extendSchemas(this.expandSchema(schema.oneOf[i]), tmp)
-      }
-    }
-
-    return this.expandRefs(extended)
-  },
-  extendSchemas: function (obj1, obj2) {
-    obj1 = $extend({}, obj1)
-    obj2 = $extend({}, obj2)
-
-    var self = this
-    var extended = {}
-    $each(obj1, function (prop, val) {
-      // If this key is also defined in obj2, merge them
-      if (typeof obj2[prop] !== 'undefined') {
-        // Required and defaultProperties arrays should be unioned together
-        if ((prop === 'required' || prop === 'defaultProperties') && typeof val === 'object' && Array.isArray(val)) {
-          // Union arrays and unique
-          extended[prop] = val.concat(obj2[prop]).reduce(function (p, c) {
-            if (p.indexOf(c) < 0) p.push(c)
-            return p
-          }, [])
-        } else if (prop === 'type' && (typeof val === 'string' || Array.isArray(val))) {
-        // Type should be intersected and is either an array or string
-          // Make sure we're dealing with arrays
-          if (typeof val === 'string') val = [val]
-          if (typeof obj2.type === 'string') obj2.type = [obj2.type]
-
-          // If type is only defined in the first schema, keep it
-          if (!obj2.type || !obj2.type.length) {
-            extended.type = val
-          } else {
-          // If type is defined in both schemas, do an intersect
-            extended.type = val.filter(function (n) {
-              return obj2.type.indexOf(n) !== -1
-            })
-          }
-
-          // If there's only 1 type and it's a primitive, use a string instead of array
-          if (extended.type.length === 1 && typeof extended.type[0] === 'string') {
-            extended.type = extended.type[0]
-          } else if (extended.type.length === 0) {
-          // Remove the type property if it's empty
-            delete extended.type
-          }
-        } else if (typeof val === 'object' && !Array.isArray(val) && val !== null) {
-        // Objects should be recursively merged
-          extended[prop] = self.extendSchemas(val, obj2[prop])
-        } else {
-          // Otherwise, use the first value
-          extended[prop] = val
-        }
-      } else {
-        // Otherwise, just use the one in obj1
-        extended[prop] = val
-      }
-    })
-    // Properties in obj2 that aren't in obj1
-    $each(obj2, function (prop, val) {
-      if (typeof obj1[prop] === 'undefined') {
-        extended[prop] = val
-      }
-    })
-
-    return extended
   },
   setCopyClipboardContents: function (value) {
     this.copyClipboard = value

--- a/src/schemaloader.js
+++ b/src/schemaloader.js
@@ -90,7 +90,7 @@ export const SchemaLoader = Class.extend({
       self.refs[url] = 'loading'
       waiting++
 
-      var fetchUrl = this._isLocalUrl(fileBase, url) ? fileBase + url : url
+      var fetchUrl = self._isLocalUrl(fileBase, url) ? fileBase + url : url
 
       // eslint-disable-next-line no-undef
       var r = new XMLHttpRequest()

--- a/src/schemaloader.js
+++ b/src/schemaloader.js
@@ -2,12 +2,12 @@ import { Class } from './class'
 import { $each, $extend } from './utilities'
 
 export const SchemaLoader = Class.extend({
-  init: function (refs, options) {
+  init: function (options) {
+    this.options = options || {}
+    this.refs = this.options.refs || {}
     this.refs_with_info = {}
     this.refs_prefix = '#/counter/'
     this.refs_counter = 1
-    this.options = options || {}
-    this.refs = refs || {}
   },
 
   load: function (schema, callback, fetchUrl, location) {

--- a/src/schemaloader.js
+++ b/src/schemaloader.js
@@ -1,0 +1,309 @@
+import { Class } from './class'
+import { $each, $extend } from './utilities'
+
+export const SchemaLoader = Class.extend({
+  init: function (refs, options) {
+    this.refs_with_info = {}
+    this.refs_prefix = '#/counter/'
+    this.refs_counter = 1
+    this.options = options || {}
+    this.refs = refs || {}
+  },
+
+  load: function (schema, callback, fetchUrl, location) {
+    var self = this
+    this._loadExternalRefs(schema, function () {
+      self._getDefinitions(schema, fetchUrl + '#/definitions/')
+      callback(self.expandRefs(schema))
+    }, fetchUrl, self._getFileBase(location))
+  },
+  _getDefinitions: function (schema, path) {
+    if (schema.definitions) {
+      for (var i in schema.definitions) {
+        if (!schema.definitions.hasOwnProperty(i)) continue
+        this.refs[path + i] = schema.definitions[i]
+        if (schema.definitions[i].definitions) {
+          this._getDefinitions(schema.definitions[i], path + i + '/definitions/')
+        }
+      }
+    }
+  },
+  _getExternalRefs: function (schema, fetchUrl) {
+    var refs = {}
+    var mergeRefs = function (newrefs) {
+      for (var i in newrefs) {
+        if (newrefs.hasOwnProperty(i)) {
+          refs[i] = true
+        }
+      }
+    }
+
+    if (schema.$ref && typeof schema.$ref !== 'object') {
+      var refCounter = this.refs_prefix + this.refs_counter++
+      if (schema.$ref.substr(0, 1) !== '#' && !this.refs[schema.$ref]) {
+        refs[schema.$ref] = true
+      }
+      this.refs_with_info[refCounter] = { fetchUrl: fetchUrl, $ref: schema.$ref }
+      schema.$ref = refCounter
+    }
+
+    for (var i in schema) {
+      if (!schema.hasOwnProperty(i)) continue
+      if (!schema[i] || typeof schema[i] !== 'object') continue
+      if (Array.isArray(schema[i])) {
+        for (var j = 0; j < schema[i].length; j++) {
+          if (schema[i][j] && typeof schema[i][j] === 'object') {
+            mergeRefs(this._getExternalRefs(schema[i][j], fetchUrl))
+          }
+        }
+      } else {
+        mergeRefs(this._getExternalRefs(schema[i], fetchUrl))
+      }
+    }
+    return refs
+  },
+  _getFileBase: function () {
+    var fileBase = this.options.ajaxBase
+    if (typeof fileBase === 'undefined') {
+      fileBase = this._getFileBaseFromFileLocation(document.location.toString())
+    }
+    return fileBase
+  },
+  _getFileBaseFromFileLocation: function (fileLocationString) {
+    var pathItems = fileLocationString.split('/')
+    pathItems.pop()
+    return pathItems.join('/') + '/'
+  },
+  _loadExternalRefs: function (schema, callback, fetchUrl, fileBase) {
+    var self = this
+    var refs = this._getExternalRefs(schema, fetchUrl)
+    var done = 0; var waiting = 0; var callbackFired = false
+
+    $each(refs, function (url) {
+      if (self.refs[url]) return
+      if (!self.options.ajax) throw new Error('Must set ajax option to true to load external ref ' + url)
+      self.refs[url] = 'loading'
+      waiting++
+
+      var fetchUrl = url
+      if (fileBase !== url.substr(0, fileBase.length) && url.substr(0, 4) !== 'http' && url.substr(0, 1) !== '/') fetchUrl = fileBase + url
+
+      // eslint-disable-next-line no-undef
+      var r = new XMLHttpRequest()
+      r.overrideMimeType('application/json')
+      r.open('GET', fetchUrl, true)
+      if (self.options.ajaxCredentials) r.withCredentials = self.options.ajaxCredentials
+      r.onreadystatechange = function () {
+        if (r.readyState !== 4) return
+        // Request succeeded
+        if (r.status === 200) {
+          var response
+          try {
+            response = JSON.parse(r.responseText)
+          } catch (e) {
+            window.console.log(e)
+            throw new Error('Failed to parse external ref ' + fetchUrl)
+          }
+          if (!(typeof response === 'boolean' || typeof response === 'object') || response === null || Array.isArray(response)) {
+            throw new Error('External ref does not contain a valid schema - ' + fetchUrl)
+          }
+
+          self.refs[url] = response
+          var fileBase = self._getFileBaseFromFileLocation(fetchUrl)
+          self._getDefinitions(response, fetchUrl + '#/definitions/')
+          self._loadExternalRefs(response, function () {
+            done++
+            if (done >= waiting && !callbackFired) {
+              callbackFired = true
+              callback()
+            }
+          }, fetchUrl, fileBase)
+        } else {
+          // Request failed
+          window.console.log(r)
+          throw new Error('Failed to fetch ref via ajax- ' + url)
+        }
+      }
+      r.send()
+    })
+
+    if (!waiting) {
+      callback()
+    }
+  },
+  expandRefs: function (schema, recurseAllOf) {
+    schema = $extend({}, schema)
+
+    while (schema.$ref) {
+      var refObj = this.refs_with_info[schema.$ref]
+      delete schema.$ref
+      var fetchUrl = ''
+      if (refObj.$ref.startsWith('#')) {
+        fetchUrl = refObj.fetchUrl
+      }
+      var ref = fetchUrl + refObj.$ref
+      if (!this.refs[ref]) ref = fetchUrl + decodeURIComponent(refObj.$ref)
+      if (!this.refs[ref]) { // if reference not found
+        console.warn("reference:'" + ref + "' not found!")
+        break
+      }
+      if (recurseAllOf) {
+        if (this.refs[ref].hasOwnProperty('allOf')) {
+          var allOf = this.refs[ref].allOf
+          for (var i = 0; i < allOf.length; i++) {
+            allOf[i] = this.expandRefs(allOf[i], true)
+          }
+        }
+      }
+      schema = this.extendSchemas(schema, this.expandSchema(this.refs[ref]))
+      // schema = this.extendSchemas(schema, $extend({}, this.refs[ref]))
+    }
+    return schema
+  },
+  expandSchema: function (schema, fileBase) {
+    var self = this
+    var extended = $extend({}, schema)
+    var i
+
+    // Version 3 `type`
+    if (typeof schema.type === 'object') {
+      // Array of types
+      if (Array.isArray(schema.type)) {
+        $each(schema.type, function (key, value) {
+          // Schema
+          if (typeof value === 'object') {
+            schema.type[key] = self.expandSchema(value)
+          }
+        })
+      } else {
+        // Schema
+        schema.type = self.expandSchema(schema.type)
+      }
+    }
+    // Version 3 `disallow`
+    if (typeof schema.disallow === 'object') {
+      // Array of types
+      if (Array.isArray(schema.disallow)) {
+        $each(schema.disallow, function (key, value) {
+          // Schema
+          if (typeof value === 'object') {
+            schema.disallow[key] = self.expandSchema(value)
+          }
+        })
+      } else {
+        // Schema
+        schema.disallow = self.expandSchema(schema.disallow)
+      }
+    }
+    // Version 4 `anyOf`
+    if (schema.anyOf) {
+      $each(schema.anyOf, function (key, value) {
+        schema.anyOf[key] = self.expandSchema(value)
+      })
+    }
+    // Version 4 `dependencies` (schema dependencies)
+    if (schema.dependencies) {
+      $each(schema.dependencies, function (key, value) {
+        if (typeof value === 'object' && !(Array.isArray(value))) {
+          schema.dependencies[key] = self.expandSchema(value)
+        }
+      })
+    }
+    // Version 4 `not`
+    if (schema.not) {
+      schema.not = this.expandSchema(schema.not)
+    }
+
+    // allOf schemas should be merged into the parent
+    if (schema.allOf) {
+      for (i = 0; i < schema.allOf.length; i++) {
+        schema.allOf[i] = this.expandRefs(schema.allOf[i], true)
+        extended = this.extendSchemas(extended, this.expandSchema(schema.allOf[i]))
+      }
+      delete extended.allOf
+    }
+    // extends schemas should be merged into parent
+    if (schema.extends) {
+      // If extends is a schema
+      if (!(Array.isArray(schema.extends))) {
+        extended = this.extendSchemas(extended, this.expandSchema(schema.extends))
+      } else {
+        // If extends is an array of schemas
+        for (i = 0; i < schema.extends.length; i++) {
+          extended = this.extendSchemas(extended, this.expandSchema(schema.extends[i]))
+        }
+      }
+      delete extended.extends
+    }
+    // parent should be merged into oneOf schemas
+    if (schema.oneOf) {
+      var tmp = $extend({}, extended)
+      delete tmp.oneOf
+      for (i = 0; i < schema.oneOf.length; i++) {
+        extended.oneOf[i] = this.extendSchemas(this.expandSchema(schema.oneOf[i]), tmp)
+      }
+    }
+
+    return this.expandRefs(extended)
+  },
+  extendSchemas: function (obj1, obj2) {
+    obj1 = $extend({}, obj1)
+    obj2 = $extend({}, obj2)
+
+    var self = this
+    var extended = {}
+    $each(obj1, function (prop, val) {
+      // If this key is also defined in obj2, merge them
+      if (typeof obj2[prop] !== 'undefined') {
+        // Required and defaultProperties arrays should be unioned together
+        if ((prop === 'required' || prop === 'defaultProperties') && typeof val === 'object' && Array.isArray(val)) {
+          // Union arrays and unique
+          extended[prop] = val.concat(obj2[prop]).reduce(function (p, c) {
+            if (p.indexOf(c) < 0) p.push(c)
+            return p
+          }, [])
+        } else if (prop === 'type' && (typeof val === 'string' || Array.isArray(val))) {
+          // Type should be intersected and is either an array or string
+          // Make sure we're dealing with arrays
+          if (typeof val === 'string') val = [val]
+          if (typeof obj2.type === 'string') obj2.type = [obj2.type]
+
+          // If type is only defined in the first schema, keep it
+          if (!obj2.type || !obj2.type.length) {
+            extended.type = val
+          } else {
+            // If type is defined in both schemas, do an intersect
+            extended.type = val.filter(function (n) {
+              return obj2.type.indexOf(n) !== -1
+            })
+          }
+
+          // If there's only 1 type and it's a primitive, use a string instead of array
+          if (extended.type.length === 1 && typeof extended.type[0] === 'string') {
+            extended.type = extended.type[0]
+          } else if (extended.type.length === 0) {
+            // Remove the type property if it's empty
+            delete extended.type
+          }
+        } else if (typeof val === 'object' && !Array.isArray(val) && val !== null) {
+          // Objects should be recursively merged
+          extended[prop] = self.extendSchemas(val, obj2[prop])
+        } else {
+          // Otherwise, use the first value
+          extended[prop] = val
+        }
+      } else {
+        // Otherwise, just use the one in obj1
+        extended[prop] = val
+      }
+    })
+    // Properties in obj2 that aren't in obj1
+    $each(obj2, function (prop, val) {
+      if (typeof obj1[prop] === 'undefined') {
+        extended[prop] = val
+      }
+    })
+
+    return extended
+  }
+})

--- a/src/schemaloader.js
+++ b/src/schemaloader.js
@@ -62,10 +62,10 @@ export const SchemaLoader = Class.extend({
     }
     return refs
   },
-  _getFileBase: function () {
+  _getFileBase: function (location) {
     var fileBase = this.options.ajaxBase
     if (typeof fileBase === 'undefined') {
-      fileBase = this._getFileBaseFromFileLocation(document.location.toString())
+      fileBase = this._getFileBaseFromFileLocation(location)
     }
     return fileBase
   },

--- a/tests/unit/schemaloader.spec.js
+++ b/tests/unit/schemaloader.spec.js
@@ -1,75 +1,101 @@
 import { SchemaLoader } from '../../src/schemaloader'
-import * as sinon from 'sinon'
+import { createFakeServer } from 'sinon'
 
 describe('SchemaLoader', () => {
   let loader
-  let fetchUrl
   let fileBase
+  let fetchUrl
 
-  beforeEach(() => {
-    loader = new SchemaLoader({}, { ajax: true })
-    fetchUrl =
-      document.location.origin + document.location.pathname.toString()
-    fileBase = loader._getFileBase(document.location.toString())
-  })
+  describe('when no external ref', () => {
+    beforeEach(() => {
+      fetchUrl =
+        document.location.origin + document.location.pathname.toString()
+      loader = new SchemaLoader()
+      fileBase = loader._getFileBase(document.location.toString())
+    })
 
-  it('should create a schema', () => {
-    expect(loader).toBeTruthy()
-  })
+    it('should create a loader', () => {
+      expect(loader).toBeTruthy()
+    })
 
-  it('load schema without $ref', () => {
-    const schema = {
-      type: 'object',
-      properties: {
-        name: { type: 'string' }
-      }
-    }
-    loader.load(schema, (schema) => { }, fetchUrl, fileBase)
-    const urls = Object.keys(loader.refs)
-    expect(urls.length).toEqual(0)
-  })
-
-  it('load schema with $ref', () => {
-    const schema = {
-      definitions: {
-        name: {
-          type: 'string',
-          minLength: 4
+    it('load schema without $ref', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' }
         }
-      },
-      type: 'object',
-      properties: {
-        fname: { $ref: '#/definitions/name' },
-        lname: { $ref: '#/definitions/name' }
       }
-    }
-    loader.load(schema, (schema) => {
-    }, fetchUrl, fileBase)
-    const urls = Object.keys(loader.refs)
-    expect(urls.length).toEqual(1)
-  })
+      loader.load(schema, schema => {}, fetchUrl, fileBase)
+      const urls = Object.keys(loader.refs)
+      expect(urls.length).toEqual(0)
+    })
 
-  it('load remote schema', (done) => {
-    const response = {
-      type: 'string',
-      minLength: 4
-    }
-    const server = sinon.fakeServer.create()
-    server.autoRespond = true
-    window.XMLHttpRequest = server.xhr
-    server.respondWith([200, { 'Content-Type': 'application/json' }, JSON.stringify(response)])
-    const schema = {
-      type: 'object',
-      properties: {
-        fname: { $ref: '/string.json' },
-        lname: { $ref: '/string.json' }
+    it('load schema with $ref', () => {
+      const schema = {
+        definitions: {
+          name: {
+            type: 'string',
+            minLength: 4
+          }
+        },
+        type: 'object',
+        properties: {
+          fname: { $ref: '#/definitions/name' },
+          lname: { $ref: '#/definitions/name' }
+        }
       }
-    }
-    loader.load(schema, (schema) => {
+      loader.load(schema, schema => {}, fetchUrl, fileBase)
       const urls = Object.keys(loader.refs)
       expect(urls.length).toEqual(1)
-      done()
+    })
+  })
+
+  describe('when external ref exists', () => {
+    let response
+    let server
+
+    beforeAll(() => {
+      response = {
+        type: 'string',
+        minLength: 4
+      }
+      server = createFakeServer()
+      server.autoRespond = true
+      window.XMLHttpRequest = server.xhr
+      server.respondWith([
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(response)
+      ])
+    })
+
+    afterAll(() => {
       server.restore()
-    }, fetchUrl, fileBase)
+    })
+
+    it('should set oprion { ajax: true }', done => {
+      fetchUrl =
+        document.location.origin + document.location.pathname.toString()
+      loader = new SchemaLoader({ ajax: true })
+      fileBase = loader._getFileBase(document.location.toString())
+
+      const schema = {
+        type: 'object',
+        properties: {
+          fname: { $ref: '/string.json' },
+          lname: { $ref: '/string.json' }
+        }
+      }
+      loader.load(
+        schema,
+        schema => {
+          const urls = Object.keys(loader.refs)
+          expect(urls.length).toEqual(1)
+          done()
+        },
+        fetchUrl,
+        fileBase
+      )
+    })
   })
 })

--- a/tests/unit/schemaloader.spec.js
+++ b/tests/unit/schemaloader.spec.js
@@ -1,0 +1,50 @@
+import { SchemaLoader } from '../../src/schemaloader'
+
+describe('SchemaLoader', () => {
+  let loader
+  let fetchUrl
+  let fileBase
+
+  beforeEach(() => {
+    loader = new SchemaLoader()
+    fetchUrl =
+            document.location.origin + document.location.pathname.toString()
+    fileBase = loader._getFileBase(document.location.toString())
+  })
+
+  it('should create a schema', () => {
+    expect(loader).toBeTruthy()
+  })
+
+  it('load schema without $ref', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' }
+      }
+    }
+    loader.load(schema, (schema) => { }, fetchUrl, fileBase)
+    const urls = Object.keys(loader.refs)
+    expect(urls.length).toEqual(0)
+  })
+
+  it('load schema with $ref', () => {
+    const schema = {
+      definitions: {
+        name: {
+          type: 'string',
+          minLength: 4
+        }
+      },
+      type: 'object',
+      properties: {
+        fname: { $ref: '#/definitions/name' },
+        lname: { $ref: '#/definitions/name' }
+      }
+    }
+    loader.load(schema, (schema) => {
+    }, fetchUrl, fileBase)
+    const urls = Object.keys(loader.refs)
+    expect(urls.length).toEqual(1)
+  })
+})


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks backward-compatibility?    | ✔️ some private method moved from core.js
| Tests pass?   | ✔️
| Fixed issues  | -
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

core.js contains codes that configure the entire editor and codes that loads the schema to editor.
The code that loads the schema is less dependent on other modules, so separate it into another module.
