### PR TITLE
fix(editors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - Fix of #629 - BS4 theme bug where basic tab was placed outside tabs container.
   - Improved IMask support for `Date`, `Number`, `IMask.MaskedEnum`, `IMask.MaskedRange` and regular expression masks. #591
   - Added support for recursive callback options.
+  - Fix of #692 - Resolves an issue where modal click detection was not working when the editor is attached inside a shadow DOM by changing the event target to use the path.
 
 ### 2.0.0-alpha-1
 

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -1036,7 +1036,9 @@ export class ObjectEditor extends AbstractEditor {
   }
 
   onOutsideModalClick (e) {
-    if (this.addproperty_holder && !this.addproperty_holder.contains(e.target) && this.adding_property) {
+    if (this.addproperty_holder &&
+      !this.addproperty_holder.contains(e.path[0] || e.composedPath()[0]) &&
+      this.adding_property) {
       e.preventDefault()
       e.stopPropagation()
       this.toggleAddProperty()


### PR DESCRIPTION
Resolves an issue where modal click detection was not working when the editor
is attached inside a shadow DOM by changing the event target to use the path.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #692 
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️
