### PR TITLE
Override getFirstTab() from themes.js to fix #681

### DIFF
--- a/src/themes/bootstrap4.js
+++ b/src/themes/bootstrap4.js
@@ -515,6 +515,10 @@ export class bootstrap4Theme extends AbstractTheme {
     return tabHolder.children[1].children[0]
   }
 
+  getFirstTab (holder) {
+    return holder.firstChild.firstChild.firstChild
+  }
+
   getProgressBar () {
     const min = 0
     const max = 100


### PR DESCRIPTION
Fixes #681 (Bootstrap4: When using category tabs, content of first tab is empty)

Also affects portion of #594

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #681
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

Test result:
```
Chrome 80.0.3987 (Linux 0.0.0): Executed 156 of 156 SUCCESS (4.832 secs / 3.834 secs)
TOTAL: 156 SUCCESS
```

Test machine:
```
$ uname -a 
Linux xxxxxxxx 4.15.0-88-generic #88-Ubuntu SMP Tue Feb 11 20:11:34 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.4 LTS
Release:	18.04
Codename:	bionic
```