### PR TITLE
Add copy button to arrays in table format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix of #701 - editors/number.js and editors/integer.js don't change values when validation is failed
 - Fix of #716 - add ignore for allOf to fall in line with existing ignores of anyOf/oneOf for additionalProperties validation
 - Fix of #714 - Checkboxes inside object tables duplicate labels from heading
+- Added copy button to arrays in table format 
 
 ### 2.0.0-dev
   - Fix of #643 - Allow use of themes not compiled directly into the build

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -225,6 +225,10 @@ languages.en = {
   */
   button_delete_row_title_short: 'Delete',
   /**
+  * Title on Copy Row buttons, short version (no parameter with the object title)
+  */
+  button_copy_row_title_short: 'Copy',
+  /**
   * Title on Collapse buttons
   */
   button_collapse: 'Collapse',

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -244,7 +244,7 @@ export class TableEditor extends ArrayEditor {
 
       if (editor.movedown_button) {
         /* Hide the move down button for the last row */
-        if (i === self.rows.length - 1) {
+        if (i === this.rows.length - 1) {
           editor.movedown_button.style.display = 'none'
         } else {
           needRowButtons = true
@@ -346,14 +346,14 @@ export class TableEditor extends ArrayEditor {
     }
 
     if (this.show_copy_button) {
-      self.rows[i].copy_button = this.getButton('', 'copy', this.translate('button_copy_row_title_short'))
-      self.rows[i].copy_button.classList.add('copy', 'json-editor-btntype-copy')
-      self.rows[i].copy_button.setAttribute('data-i', i)
-      self.rows[i].copy_button.addEventListener('click', function (e) {
+      this.rows[i].copy_button = this.getButton('', 'copy', this.translate('button_copy_row_title_short'))
+      this.rows[i].copy_button.classList.add('copy', 'json-editor-btntype-copy')
+      this.rows[i].copy_button.setAttribute('data-i', i)
+      this.rows[i].copy_button.addEventListener('click', function (e) {
         e.preventDefault()
         e.stopPropagation()
         const i = this.getAttribute('data-i') * 1
-        const value = self.getValue()
+        const value = this.getValue()
 
         each(value, (j, row) => {
           if (j === i) {
@@ -361,12 +361,12 @@ export class TableEditor extends ArrayEditor {
           }
         })
 
-        self.setValue(value)
-        self.refreshValue(true)
-        self.onChange(true)
-        self.jsoneditor.trigger('copyRow', value[value.length - 1])
+        this.setValue(value)
+        this.refreshValue(true)
+        this.onChange(true)
+        this.jsoneditor.trigger('copyRow', value[value.length - 1])
       })
-      controlsHolder.appendChild(self.rows[i].copy_button)
+      controlsHolder.appendChild(this.rows[i].copy_button)
     }
 
     if (!this.hide_move_buttons) {

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -233,7 +233,7 @@ export class TableEditor extends ArrayEditor {
       }
 
       if (editor.moveup_button) {
-        /* Hide the move up button for the first row */
+        /* Hide the moveup button for the first row */
         if (i === 0) {
           editor.moveup_button.style.display = 'none'
         } else {
@@ -243,7 +243,7 @@ export class TableEditor extends ArrayEditor {
       }
 
       if (editor.movedown_button) {
-        /* Hide the move down button for the last row */
+        /* Hide the movedown button for the last row */
         if (i === this.rows.length - 1) {
           editor.movedown_button.style.display = 'none'
         } else {

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -212,8 +212,8 @@ export class TableEditor extends ArrayEditor {
 
     let needRowButtons = false
     this.rows.forEach((editor, i) => {
-      /* Hide the delete button if we have minItems items */
       if (editor.delete_button) {
+        /* Hide the delete button if we have minItems items */
         if (minItems) {
           editor.delete_button.style.display = 'none'
         } else {
@@ -222,8 +222,8 @@ export class TableEditor extends ArrayEditor {
         }
       }
 
-      /* Hide the copy button if we have maxItems items */
       if (editor.copy_button) {
+        /* Hide the copy button if we have maxItems items */
         if (maxItems) {
           editor.copy_button.style.display = 'none'
         } else {
@@ -232,8 +232,8 @@ export class TableEditor extends ArrayEditor {
         }
       }
 
-      /* Hide the move up button for the first row */
       if (editor.moveup_button) {
+        /* Hide the move up button for the first row */
         if (i === 0) {
           editor.moveup_button.style.display = 'none'
         } else {
@@ -242,8 +242,8 @@ export class TableEditor extends ArrayEditor {
         }
       }
 
-      /* Hide the move down button for the last row */
       if (editor.movedown_button) {
+        /* Hide the move down button for the last row */
         if (i === self.rows.length - 1) {
           editor.movedown_button.style.display = 'none'
         } else {
@@ -267,48 +267,35 @@ export class TableEditor extends ArrayEditor {
       this.controls_header_cell.style.display = 'none'
     }
 
-    let controlsNeeded = false
-
     if (!this.value.length) {
-      this.delete_last_row_button.style.display = 'none'
-      this.remove_all_rows_button.style.display = 'none'
       this.table.style.display = 'none'
-    } else if (this.value.length === 1) {
-      this.table.style.display = ''
-      this.remove_all_rows_button.style.display = 'none'
-
-      /* If there are minItems items in the array, or configured to hide the delete_last_row button, hide the button beneath the rows */
-      if (minItems || this.hide_delete_last_row_buttons) {
-        this.delete_last_row_button.style.display = 'none'
-      } else {
-        this.delete_last_row_button.style.display = ''
-        controlsNeeded = true
-      }
     } else {
       this.table.style.display = ''
-
-      /* If there are minItems items in the array, or configured to hide the delete_last_row button, hide the button beneath the rows */
-      if (minItems || this.hide_delete_last_row_buttons) {
-        this.delete_last_row_button.style.display = 'none'
-      } else {
-        this.delete_last_row_button.style.display = ''
-        controlsNeeded = true
-      }
-
-      /* If there are minItems items in the array, or configured to hide the remove_all_rows_button button, hide the button beneath the rows */
-      if (minItems || this.hide_delete_all_rows_buttons) {
-        this.remove_all_rows_button.style.display = 'none'
-      } else {
-        this.remove_all_rows_button.style.display = ''
-        controlsNeeded = true
-      }
     }
+
+    let controlsNeeded = false
 
     /* If there are maxItems items in the array, or configured to hide the add_row_button button, hide the button beneath the rows */
     if (maxItems || this.hide_add_button) {
       this.add_row_button.style.display = 'none'
     } else {
       this.add_row_button.style.display = ''
+      controlsNeeded = true
+    }
+
+    /* If there are minItems items in the array, or configured to hide the delete_last_row button, hide the button beneath the rows */
+    if (!this.value.length || minItems || this.hide_delete_last_row_buttons) {
+      this.delete_last_row_button.style.display = 'none'
+    } else {
+      this.delete_last_row_button.style.display = ''
+      controlsNeeded = true
+    }
+
+    /* If there are minItems items in the array, or configured to hide the remove_all_rows_button button, hide the button beneath the rows */
+    if (this.value.length <= 1 || minItems || this.hide_delete_all_rows_buttons) {
+      this.remove_all_rows_button.style.display = 'none'
+    } else {
+      this.remove_all_rows_button.style.display = ''
       controlsNeeded = true
     }
 

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -336,11 +336,14 @@ export class TableEditor extends ArrayEditor {
           return false
         }
 
-        const i = e.currentTarget.getAttribute('data-i') * 1
-        const newval = this.getValue().filter((row, j) => j !== i) /* If this is the one we're deleting */
-        this.setValue(newval)
+        const j = e.currentTarget.getAttribute('data-i') * 1
+        const value = this.getValue()
+
+        value.splice(j, 1)
+
+        this.setValue(value)
         this.onChange(true)
-        this.jsoneditor.trigger('deleteRow', this.rows[i])
+        this.jsoneditor.trigger('deleteRow', this.rows[j])
       })
       controlsHolder.appendChild(this.rows[i].delete_button)
     }
@@ -352,19 +355,15 @@ export class TableEditor extends ArrayEditor {
       this.rows[i].copy_button.addEventListener('click', e => {
         e.preventDefault()
         e.stopPropagation()
-        const i = e.currentTarget.getAttribute('data-i') * 1
+
+        const j = e.currentTarget.getAttribute('data-i') * 1
         const value = this.getValue()
 
-        value.forEach((row, j) => {
-          if (j === i) {
-            value.push(row)
-          }
-        })
+        value.splice(j + 1, 0, value[j])
 
         this.setValue(value)
-        this.refreshValue(true)
         this.onChange(true)
-        this.jsoneditor.trigger('copyRow', value[value.length - 1])
+        this.jsoneditor.trigger('copyRow', this.rows[j + 1])
       })
       controlsHolder.appendChild(this.rows[i].copy_button)
     }
@@ -376,17 +375,15 @@ export class TableEditor extends ArrayEditor {
       this.rows[i].moveup_button.addEventListener('click', e => {
         e.preventDefault()
         e.stopPropagation()
-        const i = e.currentTarget.getAttribute('data-i') * 1
 
-        if (i <= 0) return
-        const rows = this.getValue()
-        const tmp = rows[i - 1]
-        rows[i - 1] = rows[i]
-        rows[i] = tmp
+        const j = e.currentTarget.getAttribute('data-i') * 1
+        const value = this.getValue()
 
-        this.setValue(rows)
+        value.splice(j - 1, 0, value.splice(j, 1)[0])
+
+        this.setValue(value)
         this.onChange(true)
-        this.jsoneditor.trigger('moveRow', this.rows[i - 1])
+        this.jsoneditor.trigger('moveRow', this.rows[j - 1])
       })
       controlsHolder.appendChild(this.rows[i].moveup_button)
     }
@@ -398,17 +395,15 @@ export class TableEditor extends ArrayEditor {
       this.rows[i].movedown_button.addEventListener('click', e => {
         e.preventDefault()
         e.stopPropagation()
-        const i = e.currentTarget.getAttribute('data-i') * 1
-        const rows = this.getValue()
-        if (i >= rows.length - 1) return
 
-        const tmp = rows[i + 1]
-        rows[i + 1] = rows[i]
-        rows[i] = tmp
+        const j = e.currentTarget.getAttribute('data-i') * 1
+        const value = this.getValue()
 
-        this.setValue(rows)
+        value.splice(j + 1, 0, value.splice(j, 1)[0])
+
+        this.setValue(value)
         this.onChange(true)
-        this.jsoneditor.trigger('moveRow', this.rows[i + 1])
+        this.jsoneditor.trigger('moveRow', this.rows[j + 1])
       })
       controlsHolder.appendChild(this.rows[i].movedown_button)
     }

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -207,6 +207,8 @@ export class TableEditor extends ArrayEditor {
   refreshRowButtons () {
     /* If we currently have minItems items in the array */
     const minItems = this.schema.minItems && this.schema.minItems >= this.rows.length
+    /* If we currently have maxItems items in the array */
+    const maxItems = this.schema.maxItems && this.schema.maxItems <= this.rows.length
 
     let needRowButtons = false
     this.rows.forEach((editor, i) => {
@@ -227,6 +229,16 @@ export class TableEditor extends ArrayEditor {
         } else {
           needRowButtons = true
           editor.delete_button.style.display = ''
+        }
+      }
+
+      /* Hide the copy button if we have maxItems items */
+      if (editor.copy_button) {
+        if (maxItems) {
+          editor.copy_button.style.display = 'none'
+        } else {
+          needRowButtons = true
+          editor.copy_button.style.display = ''
         }
       }
 
@@ -259,7 +271,7 @@ export class TableEditor extends ArrayEditor {
       this.table.style.display = ''
       this.remove_all_rows_button.style.display = 'none'
 
-      /* If there are minItems items in the array, or configured to hide the delete_last_row button, hide the delete button beneath the rows */
+      /* If there are minItems items in the array, or configured to hide the delete_last_row button, hide the button beneath the rows */
       if (minItems || this.hide_delete_last_row_buttons) {
         this.delete_last_row_button.style.display = 'none'
       } else {
@@ -269,6 +281,7 @@ export class TableEditor extends ArrayEditor {
     } else {
       this.table.style.display = ''
 
+      /* If there are minItems items in the array, or configured to hide the delete_last_row button, hide the button beneath the rows */
       if (minItems || this.hide_delete_last_row_buttons) {
         this.delete_last_row_button.style.display = 'none'
       } else {
@@ -276,6 +289,7 @@ export class TableEditor extends ArrayEditor {
         controlsNeeded = true
       }
 
+      /* If there are minItems items in the array, or configured to hide the remove_all_rows_button button, hide the button beneath the rows */
       if (minItems || this.hide_delete_all_rows_buttons) {
         this.remove_all_rows_button.style.display = 'none'
       } else {
@@ -284,8 +298,8 @@ export class TableEditor extends ArrayEditor {
       }
     }
 
-    /* If there are maxItems in the array, hide the add button beneath the rows */
-    if ((this.schema.maxItems && this.schema.maxItems <= this.rows.length) || this.hide_add_button) {
+    /* If there are maxItems items in the array, or configured to hide the add_row_button button, hide the button beneath the rows */
+    if (maxItems || this.hide_add_button) {
       this.add_row_button.style.display = 'none'
     } else {
       this.add_row_button.style.display = ''
@@ -316,7 +330,7 @@ export class TableEditor extends ArrayEditor {
 
     const controlsHolder = this.rows[i].table_controls
 
-    /* Buttons to delete row, move row up, and move row down */
+    /* Buttons to delete row, copy row, move row up, and move row down */
     if (!this.hide_delete_buttons) {
       this.rows[i].delete_button = this.getButton('', 'delete', this.translate('button_delete_row_title_short'))
       this.rows[i].delete_button.classList.add('delete', 'json-editor-btntype-delete')
@@ -336,6 +350,29 @@ export class TableEditor extends ArrayEditor {
         this.jsoneditor.trigger('deleteRow', this.rows[i])
       })
       controlsHolder.appendChild(this.rows[i].delete_button)
+    }
+
+    if (this.show_copy_button) {
+      self.rows[i].copy_button = this.getButton('', 'copy', this.translate('button_copy_row_title_short'))
+      self.rows[i].copy_button.classList.add('copy', 'json-editor-btntype-copy')
+      self.rows[i].copy_button.setAttribute('data-i', i)
+      self.rows[i].copy_button.addEventListener('click', function (e) {
+        const value = self.getValue()
+        e.preventDefault()
+        e.stopPropagation()
+        const i = this.getAttribute('data-i') * 1
+
+        each(value, (j, row) => {
+          if (j === i) {
+            value.push(row)
+          }
+        })
+
+        self.setValue(value)
+        self.refreshValue(true)
+        self.onChange(true)
+      })
+      controlsHolder.appendChild(self.rows[i].copy_button)
     }
 
     if (i && !this.hide_move_buttons) {

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -242,8 +242,14 @@ export class TableEditor extends ArrayEditor {
         }
       }
 
+      /* Hide the move up button for the first row */
       if (editor.moveup_button) {
-        needRowButtons = true
+        if (i === 0) {
+          editor.moveup_button.style.display = 'none'
+        } else {
+          needRowButtons = true
+          editor.moveup_button.style.display = ''
+        }
       }
     })
 
@@ -375,7 +381,7 @@ export class TableEditor extends ArrayEditor {
       controlsHolder.appendChild(self.rows[i].copy_button)
     }
 
-    if (i && !this.hide_move_buttons) {
+    if (!this.hide_move_buttons) {
       this.rows[i].moveup_button = this.getButton('', 'moveup', this.translate('button_move_up_title'))
       this.rows[i].moveup_button.classList.add('moveup', 'json-editor-btntype-move')
       this.rows[i].moveup_button.setAttribute('data-i', i)

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -364,6 +364,7 @@ export class TableEditor extends ArrayEditor {
         self.setValue(value)
         self.refreshValue(true)
         self.onChange(true)
+        self.jsoneditor.trigger('copyRow', value[value.length - 1])
       })
       controlsHolder.appendChild(self.rows[i].copy_button)
     }

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -212,16 +212,6 @@ export class TableEditor extends ArrayEditor {
 
     let needRowButtons = false
     this.rows.forEach((editor, i) => {
-      /* Hide the move down button for the last row */
-      if (editor.movedown_button) {
-        if (i === this.rows.length - 1) {
-          editor.movedown_button.style.display = 'none'
-        } else {
-          needRowButtons = true
-          editor.movedown_button.style.display = ''
-        }
-      }
-
       /* Hide the delete button if we have minItems items */
       if (editor.delete_button) {
         if (minItems) {
@@ -249,6 +239,16 @@ export class TableEditor extends ArrayEditor {
         } else {
           needRowButtons = true
           editor.moveup_button.style.display = ''
+        }
+      }
+
+      /* Hide the move down button for the last row */
+      if (editor.movedown_button) {
+        if (i === self.rows.length - 1) {
+          editor.movedown_button.style.display = 'none'
+        } else {
+          needRowButtons = true
+          editor.movedown_button.style.display = ''
         }
       }
     })

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -349,10 +349,10 @@ export class TableEditor extends ArrayEditor {
       this.rows[i].copy_button = this.getButton('', 'copy', this.translate('button_copy_row_title_short'))
       this.rows[i].copy_button.classList.add('copy', 'json-editor-btntype-copy')
       this.rows[i].copy_button.setAttribute('data-i', i)
-      this.rows[i].copy_button.addEventListener('click', function (e) {
+      this.rows[i].copy_button.addEventListener('click', e => {
         e.preventDefault()
         e.stopPropagation()
-        const i = this.getAttribute('data-i') * 1
+        const i = e.currentTarget.getAttribute('data-i') * 1
         const value = this.getValue()
 
         value.forEach((row, j) => {

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -350,10 +350,10 @@ export class TableEditor extends ArrayEditor {
       self.rows[i].copy_button.classList.add('copy', 'json-editor-btntype-copy')
       self.rows[i].copy_button.setAttribute('data-i', i)
       self.rows[i].copy_button.addEventListener('click', function (e) {
-        const value = self.getValue()
         e.preventDefault()
         e.stopPropagation()
         const i = this.getAttribute('data-i') * 1
+        const value = self.getValue()
 
         each(value, (j, row) => {
           if (j === i) {
@@ -400,6 +400,7 @@ export class TableEditor extends ArrayEditor {
         const i = e.currentTarget.getAttribute('data-i') * 1
         const rows = this.getValue()
         if (i >= rows.length - 1) return
+
         const tmp = rows[i + 1]
         rows[i + 1] = rows[i]
         rows[i] = tmp

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -355,7 +355,7 @@ export class TableEditor extends ArrayEditor {
         const i = this.getAttribute('data-i') * 1
         const value = this.getValue()
 
-        each(value, (j, row) => {
+        value.forEach((row, j) => {
           if (j === i) {
             value.push(row)
           }

--- a/tests/codeceptjs/editors/array_test.js
+++ b/tests/codeceptjs/editors/array_test.js
@@ -12,9 +12,12 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
   I.amOnPage('table-move-events.html');
   I.seeElement('[data-schemapath="root.0"]');
   I.seeElement('[data-schemapath="root.1"]');
+  I.seeElement('[data-schemapath="root.2"]');
+  I.seeElement('[data-schemapath="root.3"]');
+  I.seeElement('[data-schemapath="root.4"]');
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B"]');
+  assert.equal(value, '["A","B","C","D","E"]');
 
   I.amAcceptingPopups();
   I.click('//button[contains(@class, "json-editor-btn-moveup") and @data-i="1"]');
@@ -22,23 +25,23 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["B","A"]');
+  assert.equal(value, '["B","A","C","D","E"]');
 
   I.amAcceptingPopups();
-  I.click('//button[contains(@class, "json-editor-btn-movedown") and @data-i="0"]');
+  I.click('//button[contains(@class, "json-editor-btn-movedown") and @data-i="1"]');
   I.seeInPopup('moveRow');
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B"]');
+  assert.equal(value, '["B","C","A","D","E"]');
 
   I.amAcceptingPopups();
-  I.click('//button[contains(@class, "json-editor-btn-copy") and @data-i="1"]');
+  I.click('//button[contains(@class, "json-editor-btn-copy") and @data-i="2"]');
   I.seeInPopup('copyRow');
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B","B"]');
+  assert.equal(value, '["B","C","A","A","D","E"]');
 
   I.amAcceptingPopups();
   I.click('.json-editor-btntype-add');
@@ -46,7 +49,7 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B","B",""]');
+  assert.equal(value, '["B","C","A","A","D","E",""]');
 
   // This test will fail when using Puppeteer due to the way Puppeteer handles popups.
   // Puppeteer apparently only sees the text in the last popup, so it doesn't see the
@@ -62,7 +65,7 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B","B"]');
+  assert.equal(value, '["B","C","A","A","D","E"]');
 
   // This test will fail when using Puppeteer due to the way Puppeteer handles popups.
   I.amAcceptingPopups();

--- a/tests/codeceptjs/editors/array_test.js
+++ b/tests/codeceptjs/editors/array_test.js
@@ -38,7 +38,7 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["B","A","A"]');
+  assert.equal(value, '["A","B","B"]');
 
   I.amAcceptingPopups();
   I.click('.json-editor-btntype-add');
@@ -46,7 +46,7 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B",""]');
+  assert.equal(value, '["A","B","B",""]');
 
   // This test will fail when using Puppeteer due to the way Puppeteer handles popups.
   // Puppeteer apparently only sees the text in the last popup, so it doesn't see the
@@ -62,7 +62,7 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
-  assert.equal(value, '["A","B"]');
+  assert.equal(value, '["A","B","B"]');
 
   // This test will fail when using Puppeteer due to the way Puppeteer handles popups.
   I.amAcceptingPopups();

--- a/tests/codeceptjs/editors/array_test.js
+++ b/tests/codeceptjs/editors/array_test.js
@@ -34,7 +34,7 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
 
   I.amAcceptingPopups();
   I.click('//button[contains(@class, "json-editor-btn-copy") and @data-i="1"]');
-  I.seeInPopup('moveRow');
+  I.seeInPopup('copyRow');
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');

--- a/tests/codeceptjs/editors/array_test.js
+++ b/tests/codeceptjs/editors/array_test.js
@@ -17,7 +17,7 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
   assert.equal(value, '["A","B"]');
 
   I.amAcceptingPopups();
-  I.click('.json-editor-btn-moveup');
+  I.click('//button[contains(@class, "json-editor-btn-moveup") and @data-i="1"]');
   I.seeInPopup('moveRow');
   I.acceptPopup();
   I.click('.get-value');
@@ -25,12 +25,20 @@ Scenario('should trigger array (table) editing triggers', async (I) => {
   assert.equal(value, '["B","A"]');
 
   I.amAcceptingPopups();
-  I.click('.json-editor-btn-movedown');
+  I.click('//button[contains(@class, "json-editor-btn-movedown") and @data-i="0"]');
   I.seeInPopup('moveRow');
   I.acceptPopup();
   I.click('.get-value');
   value = await I.grabValueFrom('.debug');
   assert.equal(value, '["A","B"]');
+
+  I.amAcceptingPopups();
+  I.click('//button[contains(@class, "json-editor-btn-copy") and @data-i="1"]');
+  I.seeInPopup('moveRow');
+  I.acceptPopup();
+  I.click('.get-value');
+  value = await I.grabValueFrom('.debug');
+  assert.equal(value, '["B","A","A"]');
 
   I.amAcceptingPopups();
   I.click('.json-editor-btntype-add');

--- a/tests/pages/table-move-events.html
+++ b/tests/pages/table-move-events.html
@@ -30,6 +30,10 @@
     debug.value = JSON.stringify(editor.getValue());
   });
   editor.setValue(["A","B"]);
+  editor.on('copyRow', function () {
+    alert('copyRow');
+    console.log('copyRow');
+  });
   editor.on('moveRow', function () {
     alert('moveRow');
     console.log('moveRow');

--- a/tests/pages/table-move-events.html
+++ b/tests/pages/table-move-events.html
@@ -23,27 +23,28 @@
     }
   };
   var editor = new JSONEditor(container, {
-    schema: schema
+    schema: schema,
+    enable_array_copy: true
   });
   document.querySelector('.get-value').addEventListener('click', function () {
     debug.value = JSON.stringify(editor.getValue());
   });
   editor.setValue(["A","B"]);
   editor.on('moveRow', function () {
-    alert('moveRow')
-    console.log('moveRow')
+    alert('moveRow');
+    console.log('moveRow');
   });
   editor.on('addRow', function () {
-    alert('addRow')
-    console.log('addRow')
+    alert('addRow');
+    console.log('addRow');
   });
   editor.on('deleteRow', function () {
-    alert('deleteRow')
-    console.log('deleteRow')
+    alert('deleteRow');
+    console.log('deleteRow');
   });
   editor.on('deleteAllRows', function () {
-    alert('deleteAllRows')
-    console.log('deleteAllRows')
+    alert('deleteAllRows');
+    console.log('deleteAllRows');
   });
 </script>
 

--- a/tests/pages/table-move-events.html
+++ b/tests/pages/table-move-events.html
@@ -29,7 +29,7 @@
   document.querySelector('.get-value').addEventListener('click', function () {
     debug.value = JSON.stringify(editor.getValue());
   });
-  editor.setValue(["A","B"]);
+  editor.setValue(["A","B","C","D","E"]);
   editor.on('copyRow', function () {
     alert('copyRow');
     console.log('copyRow');


### PR DESCRIPTION
Prior to this PR, the "Copy" button would only show up on arrays that are not in the `table` format.  Live examples:
- [`table` format](https://json-editor.github.io/json-editor/?data=N4Ig9gDgLglmB2BnEAuUMDGCA2MBGqIAZglAIYDuApomALZUCsIANOHgFZUZQD62ZAJ5gArlELwwAJzplsrEIgwALKrNShYUbFUIAFKlNrwFUQRF0p2XHgqlUAjiJj2AJqgDaIC1GQBdNggpSENYGg1vKl8IswtCMikpIQUSGTJxK3I8HVMYbUsQA2i2EXgYJyoASSg1ZBQoKREqNjzamPMCsE5ucTYtHKsihSCQqTC6zQ72uKtEBph4AHMFKngROk8QDHSFVzBltjwXdzZ7aBgctjAoVSkQAJBXKiIyEWwMx/2QAF82eDIGNMCnMpAtlt8IWwni83hkPJMZp8DiB/oCrAB1OQ1O7fPwQ36KZRgCi8QzBIyEBbYsg8OAmPqqNEgPBga4gsgQAAsdkczjcvDwgl40Ne71QL2wiGajxgiAgAiF9icLiorl4OEE4rkUrYiCJJMgfAWWsl0skvDIrlceTpcl4IwsYxg4RQEp1IDIHDIAA8Te7rYgyNkqKTrXwOMY/dKA0GdLwsNgBBApVGobLYyGHaFnXU3dH08GLYkhBaramZYHCwkkoqqNInndXdr85W49WS08dDVy6sM0Wa/HIJr6o1pe2hVh4A0wJLeFBIOWY1Xi0LO1EQ3JsLxghRc82062NyvhVQuyGBHNt8SoxCgA) --> no Copy button
- [normal format](https://json-editor.github.io/json-editor/?data=N4Ig9gDgLglmB2BnEAuUMDGCA2MBGqIAZglAIYDuApomALZUCsIANOHgFZUZQD62ZAJ5gArlELwwAJzplsrEIgwALKrNShYUbFUIAFKlNrwFUQRF0p2XHgqlUAjiJj2AJqgDaIC1GQBdNggpSENYGg1vKl8IswtCMikpIVMYbUsQA2i2EXgYJyoASSg1ZBQoKREqNlSSmPN0sE5ucTYtHX0ohSCQqTDSzXq6uKtEcph4AHMFKngROk8QDDIWkFcwKbY8F3c2e2gYdrYwKFUpEADVqiIyEWxxKzWpgF82eDIGIfTRqXHnp5fLtdbvcPANhqt1go3h8rAB1OTFM5PPz/AGIZRgCi8QzBIyEcaIsg8OAmVqqGEgPBgY7fMgQAAsdkczjcvDwgl4riuNzuqGu2EQVVWMEQEAEHPsThcVFcvBwgj5ckFbHRmLl0F440VAqFkl4ZFcrlSJLkvG6Fl6MHCKH5ypAZA4ZAAHtq7UbEGQ8DpsUa+BxjK6he7Pd6sNgBBBBYG2MGvVQzcELX1o8KPXH9YkhPrDSnY96EkkJVRpFyzjalUGRSH4wWs1ydMUUzNqxnC7wsBAFWUKkLaxysPBymABbwoJBc1X033OVQGzXw7xghRSrbK2n85mOfWovGBKNF5jA/8gA===) --> Copy button shows up

This PR adds the "Copy" button to `table`-formatted arrays as well (feature parity with normally-formatted arrays).

Before this feature:
![image](https://user-images.githubusercontent.com/1757771/77838131-e6a97e00-713e-11ea-8dae-83efb742c47c.png)

With this feature:
![image](https://user-images.githubusercontent.com/1757771/77838104-a77b2d00-713e-11ea-85f0-de9de543f888.png)

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | N/A
| Updated README/docs?   | N/A
| Added CHANGELOG entry?   | ✔️

Summary of commits:
* Add copy button to arrays in table format
* Handle moveup_button with same logic as movedown_button
* Improve maintainability of refreshRowButtons()
* Update array tests
* Improve maintainability of addRow()
* Add 'copyRow' trigger

Unit test result:
```
Chrome 80.0.3987 (Linux 0.0.0): Executed 156 of 156 SUCCESS (2.562 secs / 1.806 secs)
TOTAL: 156 SUCCESS
```

Unit test machine:
```
$ uname -a
Linux xxxxxxxx 4.15.0-91-generic #92-Ubuntu SMP Fri Feb 28 11:09:48 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.4 LTS
Release:	18.04
Codename:	bionic
```