### PR TITLE
Evaluate all dependencies for an editor to determine visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 - added option `max_depth` used to specify the maximum depth of level's schema that have to be rendered
 - added option `use_default_values` used to specify if default values based on the "type" of the property have to be used
+- Fixed using multiple dependencies for an editor. Fix #703
 
 ### 2.3.0-dev
 

--- a/tests/codeceptjs/editors/object_test.js
+++ b/tests/codeceptjs/editors/object_test.js
@@ -145,3 +145,15 @@ Scenario('should have unique ids', (I) => {
   I.click('.form-group:nth-child(2) .form-check-input')
   I.waitForText('i am actually a cat')
 });
+
+Scenario('should hide properties with unfulfilled dependencies', (I) => {
+  I.amOnPage('object-with-dependencies.html');
+  I.seeElement('[data-schemapath="root.enable_option"] input');
+  I.dontSeeElement('[data-schemapath="root.make_new"] input');
+  I.dontSeeElement('[data-schemapath="root.existing_name"] input');
+
+  I.click('[data-schemapath="root.enable_option"] input');
+  I.seeElement('[data-schemapath="root.enable_option"] input');
+  I.seeElement('[data-schemapath="root.make_new"] input');
+  I.dontSeeElement('[data-schemapath="root.existing_name"] input');
+});

--- a/tests/pages/object-with-dependencies.html
+++ b/tests/pages/object-with-dependencies.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <script src="../../dist/jsoneditor.js"></script>
+</head>
+
+<body>
+  <div id="editor"></div>
+  <script>
+    const schema = {
+      "title":"Template",
+      "type":"object",
+      "properties": {
+        "enable_option": {
+          "type":"boolean",
+          "format":"checkbox"
+        },
+        "make_new": {
+          "type":"boolean",
+          "format":"checkbox",
+          "options":  {
+            "dependencies": {
+              "enable_option":true
+            }
+          }
+        },
+        "existing_name": {
+          "type":"string",
+          "invertDependency":["make_new"],
+          "options": {
+            "dependencies": {
+              "enable_option":true,
+              "make_new":false
+            }
+          }
+        }
+      },
+      "required": ["enable_option"],
+      "dependencies": {
+        "make_new": ["enable_option"],
+        "existing_name": [
+          "enable_option",
+          "make_new"
+        ]
+      },
+    };
+    const defaults = {
+        "enable_option":false,
+        "make_new":true,
+        "existing_name":"A Name"
+    };
+    const editor = new JSONEditor(document.getElementById('editor'), {
+        schema,
+        startval: defaults,
+        show_errors: 'always'
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #703 by not evaluating dependencies independently.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #703
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️

It is possible that users were relying on the previous behavior. This would be unreliable since the visibility is determined by the last dependency evaluated, which would be determined by the order of the watch events. I am not sure this order is documented/guaranteed.

Also, `checkDependency()` was left in place to minimize API changes, but it no longer behaves the same. It no longer calls `notify()` or updates visibility. Also, the state of `dependenciesFulfilled` will  likely be different when calling this function with and without this PR.