### PR TITLE
Unify the format of the module  to umd.

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -10,7 +10,8 @@ module.exports = webpackMerge(commonConfig, {
     path: helpers.root('dist/dev'),
     publicPath: '/dist/',
     filename: '[name].js',
-    chunkFilename: '[id].chunk.js'
+    chunkFilename: '[id].chunk.js',
+    libraryTarget: 'umd'
   },
 
   devServer: {

--- a/config/webpack.nonmin.js
+++ b/config/webpack.nonmin.js
@@ -11,7 +11,8 @@ module.exports = webpackMerge(commonConfig, {
     path: helpers.root('dist/nonmin'),
     publicPath: '/dist/',
     filename: '[name].js',
-    chunkFilename: '[id].chunk.js'
+    chunkFilename: '[id].chunk.js',
+    libraryTarget: 'umd'
   },
 
   plugins: [

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -6,8 +6,7 @@ const helpers = require('./helpers')
 
 const ENV = (process.env.NODE_ENV = process.env.ENV = 'production')
 
-function createConfig (target) {
-  filenameInsert = target === 'var' ? '.' : '.' + target + '.'
+function createConfig () {
   commonConfig.module.rules = [
     {
       enforce: 'pre',
@@ -39,9 +38,9 @@ function createConfig (target) {
     output: {
       path: helpers.root('dist'),
       publicPath: '/dist/',
-      filename: '[name]' + filenameInsert + 'js',
-      chunkFilename: '[id]' + filenameInsert + 'chunk.js',
-      libraryTarget: target
+      filename: '[name].js',
+      chunkFilename: '[id].chunk.js',
+      libraryTarget: 'umd'
     },
 
     optimization: {
@@ -69,7 +68,5 @@ function createConfig (target) {
 }
 
 module.exports = [
-  createConfig('var'),
-  createConfig('amd'),
-  createConfig('commonjs2')
+  createConfig()
 ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "JSON Schema based editor",
   "version": "2.2.0",
   "main": "dist/jsoneditor.js",
-  "module": "dist/jsoneditor.commonjs2.js",
   "author": {
     "name": "Jeremy Dorn",
     "email": "jeremy@jeremydorn.com",

--- a/src/core.js
+++ b/src/core.js
@@ -396,5 +396,3 @@ Object.assign(JSONEditor.defaults.themes, themes)
 Object.assign(JSONEditor.defaults.editors, editors)
 Object.assign(JSONEditor.defaults.templates, templates)
 Object.assign(JSONEditor.defaults.iconlibs, iconlibs)
-
-window.JSONEditor = JSONEditor


### PR DESCRIPTION
UMD supports both AMD and commonjs2.
 so we don't see the need to create two modules.

The build time will be bit shorter.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
