### PR TITLE
Add allOf to existing validation ignore and add .vs into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .env
 /src/themes/*.css.js
 /src/editors/*.css.js
+/.vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Cleaned how default themes, iconlibs, editors and templates are imported to JSONEditor
 - Added ability to attache editors and themes style rules to the shadowRoot if the editor is inside a Web Component.
 - Fix of #701 - editors/number.js and editors/integer.js don't change values when validation is failed
+- Fix of #716 - add ignore for allOf to fall in line with existing ignores of anyOf/oneOf for additionalProperties validation
 
 ### 2.0.0-dev
   - Fix of #643 - Allow use of themes not compiled directly into the build

--- a/src/validator.js
+++ b/src/validator.js
@@ -575,8 +575,8 @@ export class Validator {
         }
       })
 
-      /* The no_additional_properties option currently doesn't work with extended schemas that use oneOf or anyOf */
-      if (typeof schema.additionalProperties === 'undefined' && this.jsoneditor.options.no_additional_properties && !schema.oneOf && !schema.anyOf) {
+      /* The no_additional_properties option currently doesn't work with extended schemas that use oneOf or anyOf or allOf */
+      if (typeof schema.additionalProperties === 'undefined' && this.jsoneditor.options.no_additional_properties && !schema.oneOf && !schema.anyOf && !schema.allOf) {
         schema.additionalProperties = false
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #716, #237 
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️

This fixes only the validation messages appearing incorrectly for allOf because it isn't supported currently, just as oneOf and anyOf.
