### PR TITLE
Fix removed static property

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -6,6 +6,9 @@ import { templates } from './templates/index.js'
 import { iconlibs } from './iconlibs/index.js'
 import { themes } from './themes/index.js'
 import { extend, getShadowParent, hasOwnProperty } from './utilities.js'
+import { AbstractEditor } from './editor'
+import { AbstractTheme } from './theme'
+import { AbstractIconLib } from './iconlib'
 
 export class JSONEditor {
   constructor (element, options = {}) {
@@ -391,6 +394,9 @@ export class JSONEditor {
 }
 
 JSONEditor.defaults = defaults
+JSONEditor.AbstractEditor = AbstractEditor
+JSONEditor.AbstractTheme = AbstractTheme
+JSONEditor.AbstractIconLib = AbstractIconLib
 
 Object.assign(JSONEditor.defaults.themes, themes)
 Object.assign(JSONEditor.defaults.editors, editors)

--- a/tests/unit/core.spec.js
+++ b/tests/unit/core.spec.js
@@ -2,38 +2,96 @@
 Stub test file
 TODO: Write unit tests for all interfaces
 */
-import { JSONEditor } from '../../src/core';
+import { JSONEditor } from '../../src/core'
 
-const schema = 
-{
-  type:'object',
-  properties:
-  {
-    name:{type:"string"}
+const schema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' }
   }
 }
 
-
-describe("JSONEditor", function() {
+describe('JSONEditor', function () {
+  let element
+  let editor
 
   // inject the HTML fixture for the tests
-  beforeEach(function() {
-    var fixture = '<div id="fixture"></div>';
+  beforeEach(() => {
+    const fixture = '<div id="fixture"></div>'
 
-    document.body.insertAdjacentHTML(
-      'afterbegin', 
-      fixture);
-  });
+    document.body.insertAdjacentHTML('afterbegin', fixture)
+    element = document.getElementById('fixture')
+  })
 
   // remove the html fixture from the DOM
-  afterEach(function() {
-    document.body.removeChild(document.getElementById('fixture'));
-  });  
+  afterEach(() => {
+    document.body.removeChild(document.getElementById('fixture'))
+  })
 
-  it("should create an editor", function(){
-    var element = document.getElementById('fixture');
-    console.log("Attempting to create new JSONEditor");
-    var editor = new JSONEditor(element, {schema:schema });
-    expect(editor).toBeTruthy();
-  });
+  it('should create an editor', () => {
+    console.log('Attempting to create new JSONEditor')
+    editor = new JSONEditor(element, { schema: schema })
+    expect(editor).toBeTruthy()
+  })
+
+  it('can add custom iconlib', () => {
+    const customeMapping = {
+      collapse: 'key-down',
+      expand: 'key-right',
+      delete: 'trash',
+      edit: 'edit',
+      add: 'add',
+      subtract: 'minus',
+      cancel: 'check-circled',
+      save: 'create-file',
+      moveup: 'arrow-up',
+      moveright: 'arrow-right',
+      movedown: 'arrow-down',
+      moveleft: 'arrow-left',
+      copy: 'copy',
+      clear: 'close',
+      time: 'time',
+      calendar: 'calendar',
+      edit_properties: 'settings'
+    }
+    const customIconPrefix = 'mr-1 text-xl ki-'
+
+    class CustomIconLib extends JSONEditor.AbstractIconLib {
+      constructor () {
+        super()
+        this.mapping = customeMapping
+        this.icon_prefix = customIconPrefix
+      }
+    }
+    JSONEditor.defaults.iconlibs.myCustom = CustomIconLib
+    editor = new JSONEditor(element, { schema: schema, iconlib: 'myCustom' })
+    expect(editor.iconlib.icon_prefix).toBe(customIconPrefix)
+  })
+
+  it('can add custom theme', () => {
+    class CustomTheme extends JSONEditor.AbstractTheme {}
+    CustomTheme.rules = { '.slider:focus': 'box-shadow:none' }
+    JSONEditor.defaults.themes.myCustom = CustomTheme
+    editor = new JSONEditor(element, { schema: schema, theme: 'myCustom' })
+    expect(editor.theme).toBeTruthy()
+  })
+
+  it('can add custom editor', () => {
+    class CustomEditor extends JSONEditor.AbstractEditor {}
+    JSONEditor.defaults.editors.custom = CustomEditor
+    JSONEditor.defaults.resolvers.unshift((schema) => {
+      if (schema.type === 'object' && schema.format === 'custom') {
+        return 'custom'
+      }
+    })
+    const schema = {
+      type: 'object',
+      format: 'custom',
+      properties: {
+        name: { type: 'string' }
+      }
+    }
+    editor = new JSONEditor(element, { schema: schema })
+    expect(editor).toBeTruthy()
+  })
 })

--- a/tests/unit/core.spec.js
+++ b/tests/unit/core.spec.js
@@ -35,7 +35,7 @@ describe('JSONEditor', function () {
   })
 
   it('can add custom iconlib', () => {
-    const customeMapping = {
+    const customMapping = {
       collapse: 'key-down',
       expand: 'key-right',
       delete: 'trash',
@@ -59,7 +59,7 @@ describe('JSONEditor', function () {
     class CustomIconLib extends JSONEditor.AbstractIconLib {
       constructor () {
         super()
-        this.mapping = customeMapping
+        this.mapping = customMapping
         this.icon_prefix = customIconPrefix
       }
     }


### PR DESCRIPTION
AbstractEditor, AbstractTheme, AbstractIconlib had been removed in 2.2.0. re-expose them.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #723
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

At the least, added a tests