### PR TITLE
Fix non-enum string arrays with uniqueItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.3.0-dev
 
 - Removed codeception container, use `codeceptjs` as node-dev module
+- fix non-enum string arrays with uniqueItems
 
 ### 2.2.1-current
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -64,7 +64,7 @@ const enumeratedProperties = schema => {
 const arraysOfStrings = schema => {
   if (schema.type === 'array' && schema.items && !(Array.isArray(schema.items)) && ['string', 'number', 'integer'].includes(schema.items.type)) {
     if (schema.format === 'choices') return 'arrayChoices'
-    if (schema.uniqueItems) {
+    if (schema.uniqueItems && schema.items.enum) {
       /* if 'selectize' enabled it is expected to be selectized control */
       if (schema.format === 'selectize') return 'arraySelectize'
       if (schema.format === 'select2') return 'arraySelect2'

--- a/tests/codeceptjs/editors/array_test.js
+++ b/tests/codeceptjs/editors/array_test.js
@@ -896,3 +896,11 @@ Scenario('should work well with selectize multiselect editors', async (I) => {
   I.seeElement('[data-schemapath="root.0"] .selectize-dropdown-content [data-value="3"]');
   I.seeElement('[data-schemapath="root.0"] .selectize-dropdown-content [data-value="4"]');
 });
+
+Scenario('should be able to add items with uniqueItems and non-enum string type', async (I) => {
+  I.amOnPage('array-uniqueitems.html');
+  I.seeElement('.json-editor-btn-add');
+  I.click('Add item');
+  I.seeElement('[data-schemapath="root.0"]');
+  I.seeElement('.json-editor-btn-add');
+});

--- a/tests/pages/array-uniqueitems.html
+++ b/tests/pages/array-uniqueitems.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <script src="../../dist/jsoneditor.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.4/js/standalone/selectize.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.4/css/selectize.bootstrap3.css">
+</head>
+<body>
+
+<textarea class="debug" cols="30" rows="10"></textarea>
+<button class='get-value'>Get Value</button>
+<div class='container'></div>
+
+<script>
+  var container = document.querySelector('.container');
+  var debug = document.querySelector('.debug');
+  var schema = {
+    "type": "array",
+    "title": "String array with uniqueItems",
+    "uniqueItems": true,
+    "items": {
+      "type": "string"
+    }
+  };
+
+  var editor = new JSONEditor(container, {
+    schema: schema
+  });
+
+  document.querySelector('.get-value').addEventListener('click', function () {
+    debug.value = JSON.stringify(editor.getValue());
+  });
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes https://github.com/json-editor/json-editor/issues/735

Narrows the special case where string arrays with uniqueItems are replaced by selects to apply only if an enum is specified for array items.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?   |  ❌
| Tests pass?   | ✔️
| Fixed issues  | https://github.com/json-editor/json-editor/issues/735
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️
