### PR TITLE
Some theme related fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /tests/codeceptjs/output
 .vscode
 .env
+/src/*.css.js
 /src/themes/*.css.js
 /src/editors/*.css.js
 /.vs

--- a/src/core.js
+++ b/src/core.js
@@ -43,7 +43,9 @@ export class JSONEditor {
       /* Attempt to locate a shadowRoot parent (i.e. in Web Components) */
       const shadowRoot = getShadowParent(this.element)
       addRules('default', rules, shadowRoot)
-      addRules(themeName, themeClass.rules, shadowRoot)
+      if (typeof themeClass.rules !== 'undefined') {
+        addRules(themeName, themeClass.rules, shadowRoot)
+      }
     }
 
     /* Init icon class */

--- a/src/core.js
+++ b/src/core.js
@@ -32,7 +32,7 @@ export class JSONEditor {
     this.element.setAttribute('data-theme', themeName)
     // eslint-disable-next-line new-cap
     this.theme = new themeClass(this)
-    const rules = extend(themeClass.rules, this.getEditorsRules())
+    const rules = extend(styleRules, this.getEditorsRules())
 
     /* Call addNewStyleRulesToShadowRoot if shadowRoot is found, otherwise call addNewStyleRules */
     const addRules = (themeName, rules, shadowRoot) => shadowRoot
@@ -42,8 +42,8 @@ export class JSONEditor {
     if (!this.theme.options.disable_theme_rules) {
       /* Attempt to locate a shadowRoot parent (i.e. in Web Components) */
       const shadowRoot = getShadowParent(this.element)
-      addRules('default', styleRules, shadowRoot)
-      addRules(themeName, rules, shadowRoot)
+      addRules('default', rules, shadowRoot)
+      addRules(themeName, themeClass.rules, shadowRoot)
     }
 
     /* Init icon class */

--- a/src/core.js
+++ b/src/core.js
@@ -9,6 +9,7 @@ import { extend, getShadowParent, hasOwnProperty } from './utilities.js'
 import { AbstractEditor } from './editor'
 import { AbstractTheme } from './theme'
 import { AbstractIconLib } from './iconlib'
+import styleRules from './style.css.js'
 
 export class JSONEditor {
   constructor (element, options = {}) {
@@ -32,12 +33,17 @@ export class JSONEditor {
     // eslint-disable-next-line new-cap
     this.theme = new themeClass(this)
     const rules = extend(themeClass.rules, this.getEditorsRules())
+
+    /* Call addNewStyleRulesToShadowRoot if shadowRoot is found, otherwise call addNewStyleRules */
+    const addRules = (themeName, rules, shadowRoot) => shadowRoot
+      ? this.addNewStyleRulesToShadowRoot(themeName, rules, shadowRoot)
+      : this.addNewStyleRules(themeName, rules)
+
     if (!this.theme.options.disable_theme_rules) {
       /* Attempt to locate a shadowRoot parent (i.e. in Web Components) */
       const shadowRoot = getShadowParent(this.element)
-
-      /* Call addNewStyleRulesToShadowRoot if shadowRoot is found, otherwise call addNewStyleRules */
-      this[shadowRoot ? 'addNewStyleRulesToShadowRoot' : 'addNewStyleRules'](themeName, rules, shadowRoot)
+      addRules('default', styleRules, shadowRoot)
+      addRules(themeName, rules, shadowRoot)
     }
 
     /* Init icon class */
@@ -365,9 +371,11 @@ export class JSONEditor {
 
     const sheet = styleTag.sheet ? styleTag.sheet : styleTag.styleSheet
     const qualifier = this.element.nodeName.toLowerCase()
-
+    while (sheet.cssRules.length > 0) {
+      sheet.deleteRule(0)
+    }
     Object.keys(rules).forEach(selector => {
-      const sel = `${qualifier}[data-theme="${themeName}"] ${selector}`
+      const sel = themeName === 'default' ? selector : `${qualifier}[data-theme="${themeName}"] ${selector}`
 
       // all browsers, except IE before version 9
       if (sheet.insertRule) sheet.insertRule(sel + ' {' + decodeURIComponent(rules[selector]) + '}', 0)
@@ -381,7 +389,7 @@ export class JSONEditor {
     let cssText = ''
 
     Object.keys(rules).forEach(selector => {
-      const sel = `${qualifier}[data-theme="${themeName}"] ${selector}`
+      const sel = themeName === 'default' ? selector : `${qualifier}[data-theme="${themeName}"] ${selector}`
       cssText += sel + ' {' + decodeURIComponent(rules[selector]) + '}' + '\n'
     })
     const styleSheet = new CSSStyleSheet()

--- a/src/editors/array.css
+++ b/src/editors/array.css
@@ -1,0 +1,9 @@
+.json-editor-btntype-toggle {
+  margin: 0 10px 0 0;
+}
+
+.je-array-control-btn {
+  width: 100%;
+  text-align: left;
+  margin-bottom: 3px
+}

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -1,5 +1,6 @@
 import { AbstractEditor } from '../editor.js'
 import { extend, trigger } from '../utilities.js'
+import rules from './array.css.js'
 
 export class ArrayEditor extends AbstractEditor {
   askConfirmation () {
@@ -631,7 +632,6 @@ export class ArrayEditor extends AbstractEditor {
     this.collapsed = false
     this.toggle_button = this.getButton('', 'collapse', this.translate('button_collapse'))
     this.toggle_button.classList.add('json-editor-btntype-toggle')
-    this.toggle_button.style.margin = '0 10px 0 0'
     this.title.insertBefore(this.toggle_button, this.title.childNodes[0])
 
     const rowHolderDisplay = this.row_holder.style.display
@@ -742,17 +742,9 @@ export class ArrayEditor extends AbstractEditor {
     this.controls.appendChild(this.remove_all_rows_button)
 
     if (this.tabs) {
-      this.add_row_button.style.width = '100%'
-      this.add_row_button.style.textAlign = 'left'
-      this.add_row_button.style.marginBottom = '3px'
-
-      this.delete_last_row_button.style.width = '100%'
-      this.delete_last_row_button.style.textAlign = 'left'
-      this.delete_last_row_button.style.marginBottom = '3px'
-
-      this.remove_all_rows_button.style.width = '100%'
-      this.remove_all_rows_button.style.textAlign = 'left'
-      this.remove_all_rows_button.style.marginBottom = '3px'
+      this.add_row_button.classList.add('je-array-control-btn')
+      this.delete_last_row_button.classList.add('je-array-control-btn')
+      this.remove_all_rows_button.classList.add('je-array-control-btn')
     }
   }
 
@@ -788,3 +780,4 @@ export class ArrayEditor extends AbstractEditor {
     )
   }
 }
+ArrayEditor.rules = rules

--- a/src/editors/object.css
+++ b/src/editors/object.css
@@ -1,0 +1,41 @@
+.je-object__title {
+  display: inline-block
+}
+
+.je-object__controls {
+  margin: 0 0 0 10px
+}
+
+.je-object__container {
+  position: relative
+}
+
+.je-object__property-checkbox {
+  margin: 0;
+  height: auto;
+}
+
+.property-selector {
+  width: 295px;
+  max-height: 160px;
+  padding: 5px 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-left: 5px
+}
+
+.property-selector-input {
+  width: 220px;
+  margin-bottom: 0;
+  display: inline-block;
+}
+
+.json-editor-btntype-toggle {
+  margin: 0 10px 0 0;
+}
+
+.je-edit-json--textarea {
+  height: 170px !important;
+  width: 300px !important;
+  display: block;
+}

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -1,5 +1,6 @@
 import { AbstractEditor } from '../editor.js'
 import { extend, trigger, hasOwnProperty } from '../utilities.js'
+import rules from './object.css.js'
 
 export class ObjectEditor extends AbstractEditor {
   constructor (options, defaults, depth) {
@@ -552,19 +553,18 @@ export class ObjectEditor extends AbstractEditor {
         this.header.textContent = this.getTitle()
       }
       this.title = this.theme.getHeader(this.header)
+      this.title.classList.add('je-object__title')
       this.controls = this.theme.getButtonHolder()
-      this.controls.style.margin = '0 0 0 10px'
+      this.controls.classList.add('je-object__controls')
 
       this.container.appendChild(this.title)
       this.container.appendChild(this.controls)
-      this.container.style.position = 'relative'
+      this.container.classList.add('je-object__container')
 
       /* Edit JSON modal */
       this.editjson_holder = this.theme.getModal()
       this.editjson_textarea = this.theme.getTextareaInput()
-      this.editjson_textarea.style.height = '170px'
-      this.editjson_textarea.style.width = '300px'
-      this.editjson_textarea.style.display = 'block'
+      this.editjson_textarea.classList.add('je-edit-json--textarea')
       this.editjson_save = this.getButton('Save', 'save', 'Save')
       this.editjson_save.classList.add('json-editor-btntype-save')
       this.editjson_save.addEventListener('click', (e) => {
@@ -594,20 +594,13 @@ export class ObjectEditor extends AbstractEditor {
       /* Manage Properties modal */
       this.addproperty_holder = this.theme.getModal()
       this.addproperty_list = document.createElement('div')
-      this.addproperty_list.style.width = '295px'
-      this.addproperty_list.style.maxHeight = '160px'
-      this.addproperty_list.style.padding = '5px 0'
-      this.addproperty_list.style.overflowY = 'auto'
-      this.addproperty_list.style.overflowX = 'hidden'
-      this.addproperty_list.style.paddingLeft = '5px'
-      this.addproperty_list.setAttribute('class', 'property-selector')
+      this.addproperty_list.classList.add('property-selector')
       this.addproperty_add = this.getButton('add', 'add', 'add')
       this.addproperty_add.classList.add('json-editor-btntype-add')
+
       this.addproperty_input = this.theme.getFormInputField('text')
       this.addproperty_input.setAttribute('placeholder', 'Property name...')
-      this.addproperty_input.style.width = '220px'
-      this.addproperty_input.style.marginBottom = '0'
-      this.addproperty_input.style.display = 'inline-block'
+      this.addproperty_input.classList.add('property-selector-input')
       this.addproperty_add.addEventListener('click', (e) => {
         e.preventDefault()
         e.stopPropagation()
@@ -716,7 +709,6 @@ export class ObjectEditor extends AbstractEditor {
       /* Show/Hide button */
       this.collapsed = false
       this.collapse_control = this.getButton('', 'collapse', this.translate('button_collapse'))
-      this.collapse_control.style.margin = '0 10px 0 0'
       this.collapse_control.classList.add('json-editor-btntype-toggle')
       this.title.insertBefore(this.collapse_control, this.title.childNodes[0])
 
@@ -1264,3 +1256,5 @@ export class ObjectEditor extends AbstractEditor {
     })
   }
 }
+
+ObjectEditor.rules = rules

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -415,7 +415,6 @@ export class TableEditor extends ArrayEditor {
     this.collapsed = false
     this.toggle_button = this.getButton('', 'collapse', this.translate('button_collapse'))
     this.toggle_button.classList.add('json-editor-btntype-toggle')
-    this.toggle_button.style.margin = '0 10px 0 0'
     if (this.title_controls) {
       this.title.insertBefore(this.toggle_button, this.title.childNodes[0])
       this.toggle_button.addEventListener('click', e => {

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,150 @@
+.je-float-right-linkholder {
+  float: right;
+  margin-left: 10px;
+}
+
+.je-modal {
+  background-color: white;
+  border: 1px solid black;
+  box-shadow: 3px 3px black;
+  position: absolute;
+  z-index: 10;
+}
+
+.je-infobutton-icon {
+  font-size: 16px;
+  font-weight: bold;
+  padding: 0.25rem;
+  position: relative;
+  display: inline-block;
+}
+
+.je-infobutton-tooltip {
+  font-size: 12px;
+  font-weight: normal;
+  font-family: sans-serif;
+  visibility: hidden;
+  background-color: rgba(50, 50, 50, 0.75);
+  margin: 0 0.25rem;
+  color: #fafafa;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  width: 20rem;
+  position: absolute;
+}
+
+.je-header {
+  display: inline-block
+}
+
+.je-upload-preview img {
+  float: left;
+  margin: 0 0.5rem 0.5rem 0;
+  max-width: 100%;
+  max-height: 5rem;
+}
+
+.je-checkbox {
+  display: inline-block;
+  width: auto
+}
+
+.je-checkbox-control--compact {
+  display: inline-block;
+  margin-right: 1rem
+}
+
+.je-radio {
+  display: inline-block;
+  width: auto
+}
+
+.je-radio-control--compact {
+  display: inline-block;
+  margin-right: 1rem
+}
+
+.je-switcher {
+  background-color: transparent;
+  display: inline-block;
+  font-style: italic;
+  font-weight: normal;
+  height: auto;
+  width: auto;
+  margin-bottom: 0;
+  margin-left: 5px;
+  padding: 0 0 0 3px;
+}
+
+.je-textarea {
+  width: 100%;
+  height: 300px;
+  box-sizing: border-box
+}
+
+.je-range-control {
+  text-align: center
+}
+
+.je-indented-panel {
+  padding-left: 10px;
+  margin-left: 10px;
+  border-left: 1px solid #ccc
+}
+
+.je-indented-panel--top {
+  padding-left: 10px;
+  margin-left: 10px;
+}
+
+.je-tabholder {
+  float: left;
+  width: 130px;
+}
+
+.je-tabholder .content {
+  margin-left: 120px;
+}
+
+.je-tabholder--top {
+  margin-left: 10px;
+}
+
+.je-tabholder--clear {
+  clear:both;
+}
+
+.je-tab {
+  border: 1px solid #ccc;
+  border-width: 1px 0 1px 1px;
+  text-align: center;
+  line-height: 30px;
+  border-radius: 5px;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  font-weight: bold;
+  cursor: pointer
+}
+
+.je-tab--top {
+  float: left;
+  border: 1px solid #ccc;
+  border-width: 1px 1px 0px 1px;
+  text-align: center;
+  line-height: 30px;
+  border-radius: 5px;
+  padding-left: 5px;
+  padding-right: 5px;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+  font-weight: bold;
+  cursor: pointer
+}
+
+.je-block-link {
+  display: block
+}
+
+.je-media {
+  width: 100%
+}

--- a/src/theme.js
+++ b/src/theme.js
@@ -19,20 +19,14 @@ export class AbstractTheme {
 
   getFloatRightLinkHolder () {
     const el = document.createElement('div')
-    el.style = el.style || {}
-    el.style.cssFloat = 'right'
-    el.style.marginLeft = '10px'
+    el.classList.add('je-float-right-linkholder')
     return el
   }
 
   getModal () {
     const el = document.createElement('div')
-    el.style.backgroundColor = 'white'
-    el.style.border = '1px solid black'
-    el.style.boxShadow = '3px 3px black'
-    el.style.position = 'absolute'
-    el.style.zIndex = '10'
     el.style.display = 'none'
+    el.classList.add('je-modal')
     return el
   }
 
@@ -81,24 +75,10 @@ export class AbstractTheme {
   getInfoButton (text) {
     const icon = document.createElement('span')
     icon.innerText = 'ⓘ'
-    icon.style.fontSize = '16px'
-    icon.style.fontWeight = 'bold'
-    icon.style.padding = '.25rem'
-    icon.style.position = 'relative'
-    icon.style.display = 'inline-block'
+    icon.classList.add('je-infobutton-icon')
 
     const tooltip = document.createElement('span')
-    tooltip.style.fontSize = '12px'
-    icon.style.fontWeight = 'normal'
-    tooltip.style['font-family'] = 'sans-serif'
-    tooltip.style.visibility = 'hidden'
-    tooltip.style['background-color'] = 'rgba(50, 50, 50, .75)'
-    tooltip.style.margin = '0 .25rem'
-    tooltip.style.color = '#FAFAFA'
-    tooltip.style.padding = '.5rem 1rem'
-    tooltip.style['border-radius'] = '.25rem'
-    tooltip.style.width = '20rem'
-    tooltip.style.position = 'absolute'
+    tooltip.classList.add('je-infobutton-tooltip')
     tooltip.innerText = text
     icon.onmouseover = () => {
       tooltip.style.visibility = 'visible'
@@ -126,16 +106,14 @@ export class AbstractTheme {
     } else {
       el.appendChild(text)
     }
-
-    el.style.display = 'inline-block'
+    el.classList.add('je-header')
 
     return el
   }
 
   getCheckbox () {
     const el = this.getFormInputField('checkbox')
-    el.style.display = 'inline-block'
-    el.style.width = 'auto'
+    el.classList.add('je-checkbox')
     return el
   }
 
@@ -173,10 +151,7 @@ export class AbstractTheme {
     input.style.width = 'auto'
     label.insertBefore(input, label.firstChild)
     if (compact) {
-      this.applyStyles(el, {
-        display: 'inline-block',
-        marginRight: '1rem'
-      })
+      el.classList.add('je-checkbox-control--compact')
     }
 
     return el
@@ -184,11 +159,8 @@ export class AbstractTheme {
 
   getFormRadio (attributes) {
     const el = this.getFormInputField('radio')
-    for (const key in attributes) {
-      el.setAttribute(key, attributes[key])
-    }
-    el.style.display = 'inline-block'
-    el.style.width = 'auto'
+    Object.keys(attributes).forEach(key => el.setAttribute(key, attributes[key]))
+    el.classList.add('je-radio')
     return el
   }
 
@@ -205,10 +177,7 @@ export class AbstractTheme {
     input.style.width = 'auto'
     label.insertBefore(input, label.firstChild)
     if (compact) {
-      this.applyStyles(el, {
-        display: 'inline-block',
-        marginRight: '1rem'
-      })
+      el.classList.add('je-radio-control--compact')
     }
 
     return el
@@ -222,15 +191,7 @@ export class AbstractTheme {
 
   getSwitcher (options) {
     const switcher = this.getSelectInput(options, false)
-    switcher.style.backgroundColor = 'transparent'
-    switcher.style.display = 'inline-block'
-    switcher.style.fontStyle = 'italic'
-    switcher.style.fontWeight = 'normal'
-    switcher.style.height = 'auto'
-    switcher.style.marginBottom = 0
-    switcher.style.marginLeft = '5px'
-    switcher.style.padding = '0 0 0 3px'
-    switcher.style.width = 'auto'
+    switcher.classList.add('je-switcher')
     return switcher
   }
 
@@ -254,10 +215,7 @@ export class AbstractTheme {
 
   getTextareaInput () {
     const el = document.createElement('textarea')
-    el.style = el.style || {}
-    el.style.width = '100%'
-    el.style.height = '300px'
-    el.style.boxSizing = 'border-box'
+    el.classList.add('je-textarea')
     return el
   }
 
@@ -281,7 +239,7 @@ export class AbstractTheme {
 
   getRangeControl (input, output) {
     const el = document.createElement('div')
-    el.style.textAlign = 'center'
+    el.classList.add('je-range-control')
     if (output) el.appendChild(output)
     el.appendChild(input)
     return el
@@ -316,18 +274,13 @@ export class AbstractTheme {
 
   getIndentedPanel () {
     const el = document.createElement('div')
-    el.style = el.style || {}
-    el.style.paddingLeft = '10px'
-    el.style.marginLeft = '10px'
-    el.style.borderLeft = '1px solid #ccc'
+    el.classList.add('je-indented-panel')
     return el
   }
 
   getTopIndentedPanel () {
     const el = document.createElement('div')
-    el.style = el.style || {}
-    el.style.paddingLeft = '10px'
-    el.style.marginLeft = '10px'
+    el.classList.add('je-indented-panel--top')
     return el
   }
 
@@ -441,14 +394,14 @@ export class AbstractTheme {
   getTabHolder (propertyName) {
     const pName = (typeof propertyName === 'undefined') ? '' : propertyName
     const el = document.createElement('div')
-    el.innerHTML = `<div style='float: left; width: 130px;' class='tabs'></div><div class='content' style='margin-left: 120px;' id='${pName}'></div><div style='clear:both;'></div>`
+    el.innerHTML = `<div class='je-tabholder tabs'></div><div class='content' id='${pName}'></div><div class='je-tabholder--clear'></div>`
     return el
   }
 
   getTopTabHolder (propertyName) {
     const pName = (typeof propertyName === 'undefined') ? '' : propertyName
     const el = document.createElement('div')
-    el.innerHTML = `<div class='tabs' style='margin-left: 10px;'></div><div style='clear:both;'></div><div class='content' id='${pName}'></div>`
+    el.innerHTML = `<div class='tabs je-tabholder--top'></div><div class='je-tabholder--clear'></div><div class='content' id='${pName}'></div>`
     return el
   }
 
@@ -479,40 +432,15 @@ export class AbstractTheme {
     const el = document.createElement('div')
     el.appendChild(span)
     el.id = tabId
-    el.style = el.style || {}
-    this.applyStyles(el, {
-      border: '1px solid #ccc',
-      borderWidth: '1px 0 1px 1px',
-      textAlign: 'center',
-      lineHeight: '30px',
-      borderRadius: '5px',
-      borderBottomRightRadius: 0,
-      borderTopRightRadius: 0,
-      fontWeight: 'bold',
-      cursor: 'pointer'
-    })
+    el.classList.add('je-tab')
     return el
   }
 
   getTopTab (span, tabId) {
     const el = document.createElement('div')
-    el.id = tabId
     el.appendChild(span)
-    el.style = el.style || {}
-    this.applyStyles(el, {
-      float: 'left',
-      border: '1px solid #ccc',
-      borderWidth: '1px 1px 0px 1px',
-      textAlign: 'center',
-      lineHeight: '30px',
-      borderRadius: '5px',
-      paddingLeft: '5px',
-      paddingRight: '5px',
-      borderBottomRightRadius: 0,
-      borderBottomLeftRadius: 0,
-      fontWeight: 'bold',
-      cursor: 'pointer'
-    })
+    el.id = tabId
+    el.classList.add('je-tab--top')
     return el
   }
 
@@ -566,7 +494,7 @@ export class AbstractTheme {
 
   getBlockLink () {
     const link = document.createElement('a')
-    link.style.display = 'block'
+    link.classList.add('je-block-link')
     return link
   }
 
@@ -582,7 +510,7 @@ export class AbstractTheme {
 
   createMediaLink (holder, link, media) {
     holder.appendChild(link)
-    media.style.width = '100%'
+    media.classList.add('je-media')
     holder.appendChild(media)
   }
 
@@ -655,6 +583,3 @@ export class AbstractTheme {
     progressBar.removeAttribute('value')
   }
 }
-
-/* Custom stylesheet rules. format: "selector" : "CSS rules" */
-AbstractTheme.rules = { '.je-upload-preview img': 'float:left;margin:0 0.5rem 0.5rem 0;max-width:100%;max-height:100px' }

--- a/src/themes/html.css
+++ b/src/themes/html.css
@@ -1,30 +1,30 @@
-je-form-input-label {
+.je-form-input-label {
   display: block;
   margin-bottom: 3px;
   font-weight: bold;
 }
-je-form-input-description {
+.je-form-input-description {
   display: inline-block;
   margin: 0;
   font-size: 0.8em;
   font-style: italic;
 }
-je-indented-panel {
+.je-indented-panel {
   padding: 5px;
   margin: 10px;
   border-radius: 3px;
   border: 1px solid #ddd;
 }
-je-child-editor-holder {
+.je-child-editor-holder {
   margin-bottom: 8px;
 }
-je-header-button-holder {
+.je-header-button-holder {
   display: inline-block;
   margin-left: 10px;
   font-size: 0.8em;
   vertical-align: middle;
 }
-je-table {
+.je-table {
   margin-bottom: 5px;
   border-bottom: 1px solid #ccc;
 }

--- a/tests/unit/core.spec.js
+++ b/tests/unit/core.spec.js
@@ -78,6 +78,13 @@ describe('JSONEditor', function () {
     expect(editor.theme).toBeTruthy()
   })
 
+  it('can add custom theme (no custom css rules)', () => {
+    class CustomTheme extends JSONEditor.AbstractTheme {}
+    JSONEditor.defaults.themes.myCustom2 = CustomTheme
+    editor = new JSONEditor(element, { schema: schema, theme: 'myCustom2' })
+    expect(editor.theme).toBeTruthy()
+  })
+
   it('can add custom editor', () => {
     class CustomEditor extends JSONEditor.AbstractEditor {}
     JSONEditor.defaults.editors.custom = CustomEditor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #763
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

Suggest some theme related fixes.

* selectors in "html theme" is incorrect.
* AbstractTheme.rules is a static property and is not usually read. Change it as the default stylesheet to be read by all themes.
* remove the css rule every time when generating multiple editors on the same page, to prevent to duplicate rules
* css rules of editor, such as ObjectEditor will be integrated into the default rules instead of each theme
* add "undefined" check for custom editor without css rule(#763)
