### PR TITLE
fix: When schema is readonly, input is disabled and readonly.

### DIFF
--- a/src/editors/button.js
+++ b/src/editors/button.js
@@ -38,7 +38,7 @@ export class ButtonEditor extends AbstractEditor {
     this.input.addEventListener('click', options.action, false)
 
     if (this.schema.readOnly || this.schema.readonly || this.schema.template) {
-      this.always_disabled = true
+      this.disable(true)
       this.input.setAttribute('readonly', 'true')
     }
 

--- a/src/editors/checkbox.js
+++ b/src/editors/checkbox.js
@@ -40,7 +40,7 @@ export class CheckboxEditor extends AbstractEditor {
     this.control = this.theme.getFormControl(this.label, this.input, this.description, this.infoButton)
 
     if (this.schema.readOnly || this.schema.readonly) {
-      this.always_disabled = true
+      this.disable(true)
       this.input.disabled = true
     }
 

--- a/src/editors/radio.js
+++ b/src/editors/radio.js
@@ -46,7 +46,7 @@ export class RadioEditor extends SelectEditor {
     }
 
     if (this.schema.readOnly || this.schema.readonly) {
-      this.always_disabled = true
+      this.disable(true)
       for (let j = 0; j < this.radioGroup.length; j++) {
         this.radioGroup[j].disabled = true
       }

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -170,7 +170,7 @@ export class SelectEditor extends AbstractEditor {
     this.theme.setSelectOptions(this.input, this.enum_options, this.enum_display)
 
     if (this.schema.readOnly || this.schema.readonly) {
-      this.always_disabled = true
+      this.disable(true)
       this.input.disabled = true
     }
 

--- a/src/editors/signature.js
+++ b/src/editors/signature.js
@@ -53,7 +53,7 @@ export class SignatureEditor extends StringEditor {
       if (this.options.compact) this.container.setAttribute('class', `${this.container.getAttribute('class')} compact`)
 
       if (this.schema.readOnly || this.schema.readonly) {
-        this.always_disabled = true
+        this.disable(true)
         Array.from(this.inputs).forEach(input => {
           canvas.setAttribute('readOnly', 'readOnly')
           input.disabled = true

--- a/src/editors/starrating.js
+++ b/src/editors/starrating.js
@@ -59,7 +59,7 @@ export class StarratingEditor extends StringEditor {
     }
 
     if (this.schema.readOnly || this.schema.readonly) {
-      this.always_disabled = true
+      this.disable(true)
       for (let j = 0; j < this.radioGroup.length; j++) {
         this.radioGroup[j].disabled = true
       }

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -127,7 +127,7 @@ export class StringEditor extends AbstractEditor {
     } else if (this.options.input_width) this.input.style.width = this.options.input_width
 
     if (this.schema.readOnly || this.schema.readonly || this.schema.template) {
-      this.always_disabled = true
+      this.disable(true)
       this.input.setAttribute('readonly', 'true')
     }
 


### PR DESCRIPTION
problem: [readonly] and [disabled] attributes should be applied, but only readonly si applied on buld. disabled attribute is applied after show-hide property editor.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
