### PR TITLE
Default array format to table if no format specified

### DIFF
--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -63,6 +63,7 @@ const enumeratedProperties = schema => {
 /* Specialized editors for arrays of strings */
 const arraysOfStrings = schema => {
   if (schema.type === 'array' && schema.items && !(Array.isArray(schema.items)) && ['string', 'number', 'integer'].includes(schema.items.type)) {
+    if (!schema.format) return 'table'
     if (schema.format === 'choices') return 'arrayChoices'
     if (schema.uniqueItems) {
       /* if 'selectize' enabled it is expected to be selectized control */

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -63,12 +63,12 @@ const enumeratedProperties = schema => {
 /* Specialized editors for arrays of strings */
 const arraysOfStrings = schema => {
   if (schema.type === 'array' && schema.items && !(Array.isArray(schema.items)) && ['string', 'number', 'integer'].includes(schema.items.type)) {
-    if (!schema.format) return 'table'
     if (schema.format === 'choices') return 'arrayChoices'
     if (schema.uniqueItems) {
       /* if 'selectize' enabled it is expected to be selectized control */
       if (schema.format === 'selectize') return 'arraySelectize'
       if (schema.format === 'select2') return 'arraySelect2'
+      if (!schema.format) return 'table'
       if (schema.format !== 'table') return 'multiselect' /* otherwise it is select */
     }
   }

--- a/tests/unit/editor.spec.js
+++ b/tests/unit/editor.spec.js
@@ -63,6 +63,7 @@ describe('Editor', () => {
     editor = new JSONEditor(element, {
       schema: {
         type: 'array',
+        format: 'multiselect',
         title: 'Checkboxes',
         items: {
           title: 'Rating',

--- a/tests/unit/editor.spec.js
+++ b/tests/unit/editor.spec.js
@@ -63,7 +63,6 @@ describe('Editor', () => {
     editor = new JSONEditor(element, {
       schema: {
         type: 'array',
-        format: 'multiselect',
         title: 'Checkboxes',
         items: {
           title: 'Rating',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | Resolves #837 
| Updated README/docs?   | ❌ (maybe consider removing `format: table` from README examples and demos in `/docs`)
| Added CHANGELOG entry?   | ❌
