### PR TITLE
Get multiselect values from a callback.

### DIFF
--- a/src/editors/multiselect.js
+++ b/src/editors/multiselect.js
@@ -33,18 +33,28 @@ export class MultiSelectEditor extends AbstractEditor {
     this.option_keys = []
     this.option_titles = []
 
-    let i
-    const itemsSchema = this.jsoneditor.expandRefs(this.schema.items || {})
-    const e = itemsSchema.enum || []
-    const t = itemsSchema.options ? itemsSchema.options.enum_titles || [] : []
+    if (!this.schema.items.enum) {
+      let callback
+      callback = this.expandCallbacks('template', { template: this.schema.items.options.values })
+      if (typeof callback.template === 'function') this.values_callback = callback.template
+      callback = this.expandCallbacks('template', { template: this.schema.items.options.titles })
+      if (typeof callback.template === 'function') this.titles_callback = callback.template
+      callback = this.expandCallbacks('template', { template: this.schema.items.options.updated })
+      if (typeof callback.template === 'function') this.updated_callback = callback.template
+    } else {
+      let i
+      const itemsSchema = this.jsoneditor.expandRefs(this.schema.items || {})
+      const e = itemsSchema.enum || []
+      const t = itemsSchema.options ? itemsSchema.options.enum_titles || [] : []
 
-    for (i = 0; i < e.length; i++) {
-      /* If the sanitized value is different from the enum value, don't include it */
-      if (this.sanitize(e[i]) !== e[i]) continue
+      for (i = 0; i < e.length; i++) {
+        /* If the sanitized value is different from the enum value, don't include it */
+        if (this.sanitize(e[i]) !== e[i]) continue
 
-      this.option_keys.push(`${e[i]}`)
-      this.option_titles.push(`${t[i] || e[i]}`)
-      this.select_values[`${e[i]}`] = e[i]
+        this.option_keys.push(`${e[i]}`)
+        this.option_titles.push(`${t[i] || e[i]}`)
+        this.select_values[`${e[i]}`] = e[i]
+      }
     }
   }
 

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -138,6 +138,10 @@ export class SelectEditor extends AbstractEditor {
       /* Now, enumSource is an array of sources */
       /* Walk through this array and fix up the values */
       for (i = 0; i < this.enumSource.length; i++) {
+        if (this.enumSource[i].source) {
+          callback = this.expandCallbacks('template', { template: this.enumSource[i].source })
+          if (typeof callback.template === 'function') this.enumSource[i].source = callback.template
+        }
         if (this.enumSource[i].value) {
           callback = this.expandCallbacks('template', { template: this.enumSource[i].value })
           if (typeof callback.template === 'function') this.enumSource[i].value = callback.template
@@ -234,8 +238,12 @@ export class SelectEditor extends AbstractEditor {
           selectTitles = selectTitles.concat(this.enumSource[i])
         } else {
           let items = []
+          /* Dynamic retrived list of items from callback */
+          if (typeof this.enumSource[i].source === 'function') {
+            var newItems = this.enumSource[i].source({ watched: vars })
+            if (Array.isArray(newItems)) items = newItems
           /* Static list of items */
-          if (Array.isArray(this.enumSource[i].source)) {
+          } else if (Array.isArray(this.enumSource[i].source)) {
             items = this.enumSource[i].source
             /* A watched field */
           } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

New feature to retrieve the list of multiselect values from a callback. It can be used using this js callbacks and json config data.

		window.JSONEditor.defaults.callbacks.template = {
			"getEntityAttibutesCB": (jseditor, e) => {
				var entity = entitiesMap.get(e.watched.entity);
				if (entity != null) {
					return entity.attributes;
				} else {
					return [];
				}
			},
			"getEntityAttibuteNamesCB": (jseditor, e) => {
				var entity = entitiesMap.get(e.watched.entity);
				if (entity != null) {
					return entity.attributeNames;
				} else {
					return [];
				}
			},
			"isEntityChangedCB": (jseditor, e) => {
				if (e.watched.entity != null && previouseSelected[e.path] !== e.watched.entity) {
					previouseSelected[e.path] = e.watched.entity;
					return true;
				} else {
					return false;
				}
			}
		};


          "update": {
            "type": "array",
            "format": "select2",
            "options": {
              "grid_columns": 12,
              "select2": {
                "tags": false
              }
            },
            "title": "Update",
            "uniqueItems": true,
            "watch": {
              "entity": "entities.entity"
            },
            "items": {
              "type": "string",
              "options": {
                "values": "getEntityAttibutesCB",
                "titles": "getEntityAttibuteNamesCB",
                "updated": "isEntityChangedCB"
              }
            }
          }



