### PR TITLE
Support to translate user defined elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Ability to translate individual text elements, e.g. Titles, InfoTexts, Descriptions
+
 ### 2.5.1
 
 - Fix for #837 and chekboxes not displaying error messages #843

--- a/src/core.js
+++ b/src/core.js
@@ -22,6 +22,7 @@ export class JSONEditor {
     this.schema = this.options.schema
     this.template = this.options.template
     this.translate = this.options.translate || JSONEditor.defaults.translate
+    this.translateElement = this.options.translateElement || JSONEditor.defaults.translateElement
     this.uuid = 0
     this.__data = {}
     const themeName = this.options.theme || JSONEditor.defaults.theme

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -286,8 +286,8 @@ function translate (key, variables) {
 
 /* Text element translate function */
 
-function translateElement(text, variables) {
-  return text;
+function translateElement (text, variables) {
+  return text
 }
 
 /* Default options when initializing JSON Editor */

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -284,6 +284,12 @@ function translate (key, variables) {
   return string
 }
 
+/* Text element translate function */
+
+function translateElement(text, variables) {
+  return text;
+}
+
 /* Default options when initializing JSON Editor */
 const options = {
   upload,
@@ -307,5 +313,6 @@ export const defaults = {
   custom_validators,
   default_language,
   language,
-  translate
+  translate,
+  translateElement
 }

--- a/src/editor.js
+++ b/src/editor.js
@@ -11,6 +11,7 @@ export class AbstractEditor {
     this.template_engine = this.jsoneditor.template
     this.iconlib = this.jsoneditor.iconlib
     this.translate = this.jsoneditor.translate || this.defaults.translate
+    this.translateElement = this.jsoneditor.translateElement || this.defaults.translateElement
     this.original_schema = options.schema
     this.schema = this.jsoneditor.expandSchema(this.original_schema)
     this.active = true
@@ -460,10 +461,10 @@ export class AbstractEditor {
 
   getHeaderText (titleOnly) {
     if (this.header_text) return this.header_text
-    else if (titleOnly) return this.schema.title
+    else if (titleOnly) return this.translateElement(this.schema.title)
     else return this.getTitle()
   }
-
+  
   cleanText (txt) {
     /* Clean out HTML tags from txt */
     const tmp = document.createElement('div')
@@ -569,7 +570,7 @@ export class AbstractEditor {
   }
 
   getTitle () {
-    return this.schema.title || this.key
+    return this.translateElement(this.schema.title || this.key)
   }
 
   enable () {

--- a/src/editor.js
+++ b/src/editor.js
@@ -464,7 +464,7 @@ export class AbstractEditor {
     else if (titleOnly) return this.translateElement(this.schema.title)
     else return this.getTitle()
   }
-  
+
   cleanText (txt) {
     /* Clean out HTML tags from txt */
     const tmp = document.createElement('div')

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -162,7 +162,7 @@ export class ArrayEditor extends AbstractEditor {
     if (!this.item_title) {
       if (this.schema.items && !Array.isArray(this.schema.items)) {
         const tmp = this.jsoneditor.expandRefs(this.schema.items)
-        this.item_title = tmp.title || this.translate('default_array_item_title')
+        this.item_title = this.translateElement(tmp.title) || this.translate('default_array_item_title')
       } else {
         this.item_title = this.translate('default_array_item_title')
       }
@@ -200,7 +200,7 @@ export class ArrayEditor extends AbstractEditor {
     schema = this.jsoneditor.expandRefs(schema)
 
     this.item_info[stringified] = {
-      title: schema.title || this.translate('default_array_item_title'),
+      title: this.translateElement(schema.title) || this.translate('default_array_item_title'),
       default: schema.default,
       width: 12,
       child_editors: schema.properties || schema.items

--- a/src/editors/base64.js
+++ b/src/editors/base64.js
@@ -32,7 +32,7 @@ export class Base64Editor extends AbstractEditor {
 
   build () {
     this.title = this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
-    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.options.infoText)
+    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.translateElement(this.options.infoText))
 
     /* Input that holds the base64 string */
     this.input = this.theme.getFormInputField('hidden')
@@ -90,7 +90,7 @@ export class Base64Editor extends AbstractEditor {
       })
     }
 
-    this.preview = this.theme.getFormInputDescription(this.schema.description)
+    this.preview = this.theme.getFormInputDescription(this.translateElement(this.schema.description))
     this.container.appendChild(this.preview)
 
     this.control = this.theme.getFormControl(this.label, this.uploader || this.input, this.preview, this.infoButton)

--- a/src/editors/button.js
+++ b/src/editors/button.js
@@ -24,7 +24,7 @@ export class ButtonEditor extends AbstractEditor {
 
     /* Get options, either global options from "this.defaults.options.button" or */
     /* single property options from schema "options.button" */
-    const title = this.schema.title || this.key
+    const title = this.translateElement(this.schema.title) || this.key
     const options = this.expandCallbacks('button', extend({}, {
       icon: '',
       validated: false,

--- a/src/editors/checkbox.js
+++ b/src/editors/checkbox.js
@@ -31,8 +31,8 @@ export class CheckboxEditor extends AbstractEditor {
       this.label.htmlFor = this.formname
     }
 
-    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description)
-    if (this.options.infoText && !this.options.compact) this.infoButton = this.theme.getInfoButton(this.options.infoText)
+    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.translateElement(this.schema.description))
+    if (this.options.infoText && !this.options.compact) this.infoButton = this.theme.getInfoButton(this.translateElement(this.options.infoText))
     if (this.options.compact) this.container.classList.add('compact')
 
     this.input = this.theme.getCheckbox()

--- a/src/editors/info.js
+++ b/src/editors/info.js
@@ -11,7 +11,7 @@ export class InfoEditor extends ButtonEditor {
   }
 
   getTitle () {
-    return this.schema.title
+    return this.translateElement(this.schema.title) 
   }
 
   getNumColumns () {

--- a/src/editors/info.js
+++ b/src/editors/info.js
@@ -11,7 +11,7 @@ export class InfoEditor extends ButtonEditor {
   }
 
   getTitle () {
-    return this.translateElement(this.schema.title) 
+    return this.translateElement(this.schema.title)
   }
 
   getNumColumns () {

--- a/src/editors/multiselect.js
+++ b/src/editors/multiselect.js
@@ -51,8 +51,8 @@ export class MultiSelectEditor extends AbstractEditor {
   build () {
     let i
     if (!this.options.compact) this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
-    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description)
-    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.options.infoText)
+    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.translateElement(this.schema.description))
+    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.translateElement(this.options.infoText))
     if (this.options.compact) this.container.classList.add('compact')
 
     if ((!this.schema.format && this.option_keys.length < 8) || this.schema.format === 'checkbox') {

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -230,7 +230,7 @@ export class ObjectEditor extends AbstractEditor {
         const containerSimple = document.createElement('div')
         /* This will be the place to (re)build tabs and panes */
         /* tabs_holder has 2 childs, [0]: ul.nav.nav-tabs and [1]: div.tab-content */
-        const newTabsHolder = this.theme.getTopTabHolder(this.schema.title)
+        const newTabsHolder = this.theme.getTopTabHolder(this.translateElement(this.schema.title))
         /* child [1] of previous, stores panes */
         const newTabPanesContainer = this.theme.getTopTabContentHolder(newTabsHolder)
 
@@ -657,11 +657,11 @@ export class ObjectEditor extends AbstractEditor {
       this.row_container = this.theme.getGridContainer()
 
       if (isCategoriesFormat) {
-        this.tabs_holder = this.theme.getTopTabHolder(this.getValidId(this.schema.title))
+        this.tabs_holder = this.theme.getTopTabHolder(this.getValidId(this.translateElement(this.schema.title)))
         this.tabPanesContainer = this.theme.getTopTabContentHolder(this.tabs_holder)
         this.editor_holder.appendChild(this.tabs_holder)
       } else {
-        this.tabs_holder = this.theme.getTabHolder(this.getValidId(this.schema.title))
+        this.tabs_holder = this.theme.getTabHolder(this.getValidId(this.translateElement(this.schema.title)))
         this.tabPanesContainer = this.theme.getTabContentHolder(this.tabs_holder)
         this.editor_holder.appendChild(this.row_container)
       }

--- a/src/editors/radio.js
+++ b/src/editors/radio.js
@@ -9,8 +9,8 @@ export class RadioEditor extends SelectEditor {
   build () {
     this.label = ''
     if (!this.options.compact) this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
-    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description)
-    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.options.infoText)
+    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.translateElement(this.schema.description))
+    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.translateElement(this.options.infoText))
     if (this.options.compact) this.container.classList.add('compact')
 
     this.radioContainer = document.createElement('div')

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -77,7 +77,7 @@ export class SelectEditor extends AbstractEditor {
 
       this.schema.enum.forEach((option, i) => {
         this.enum_options[i] = `${option}`
-        this.enum_display[i] = `${_this.translateElement(display[i]) || option}`
+        this.enum_display[i] = `${this.translateElement(display[i]) || option}`
         this.enum_values[i] = this.typecast(option)
       })
 

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -77,7 +77,7 @@ export class SelectEditor extends AbstractEditor {
 
       this.schema.enum.forEach((option, i) => {
         this.enum_options[i] = `${option}`
-        this.enum_display[i] = `${display[i] || option}`
+        this.enum_display[i] = `${_this.translateElement(display[i]) || option}`
         this.enum_values[i] = this.typecast(option)
       })
 
@@ -162,8 +162,8 @@ export class SelectEditor extends AbstractEditor {
 
   build () {
     if (!this.options.compact) this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
-    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description)
-    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.options.infoText)
+    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.translateElement(this.schema.description))
+    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.translateElement(this.options.infoText))
     if (this.options.compact) this.container.classList.add('compact')
 
     this.input = this.theme.getSelectInput(this.enum_options, false)

--- a/src/editors/starrating.js
+++ b/src/editors/starrating.js
@@ -4,8 +4,8 @@ import rules from './starrating.css.js'
 export class StarratingEditor extends StringEditor {
   build () {
     if (!this.options.compact) this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
-    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description)
-    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.options.infoText)
+    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.translateElement(this.schema.description))
+    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.translateElement(this.options.infoText))
     if (this.options.compact) this.container.classList.add('compact')
 
     this.ratingContainer = document.createElement('div')

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -70,8 +70,8 @@ export class StringEditor extends AbstractEditor {
 
   build () {
     if (!this.options.compact) this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
-    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description)
-    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.options.infoText)
+    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.translateElement(this.schema.description))
+    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.translateElement(this.options.infoText))
 
     this.format = this.schema.format
     if (!this.format && this.schema.media && this.schema.media.type) {

--- a/src/editors/upload.js
+++ b/src/editors/upload.js
@@ -8,8 +8,8 @@ export class UploadEditor extends AbstractEditor {
 
   build () {
     if (!this.options.compact) this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
-    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description)
-    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.options.infoText)
+    if (this.schema.description) this.description = this.theme.getFormInputDescription(this.translateElement(this.schema.description))
+    if (this.options.infoText) this.infoButton = this.theme.getInfoButton(this.translateElement(this.options.infoText))
 
     /* Editor options */
     this.options = this.expandCallbacks('upload', extend({}, {

--- a/src/themes/tailwind.js
+++ b/src/themes/tailwind.js
@@ -60,7 +60,7 @@ export class tailwindTheme extends AbstractTheme {
   }
 
   getTitle () {
-    return this.schema.title
+    return this.translateElement(this.schema.title)
   }
 
   getSelectInput (options, multiple) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -7,6 +7,7 @@ export class Validator {
     this.schema = schema || this.jsoneditor.schema
     this.options = options || {}
     this.translate = this.jsoneditor.translate || defaults.translate
+    this.translateElement = this.jsoneditor.translateElement || defaults.translateElement
     this.defaults = defaults
 
     this._validateSubSchema = {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | N/A
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️

The PR provides the ability to translate individual text elements, e.g. Titles, InfoTexts, Descriptions while maintaining one definition schema.
It introduces a separate TranslateElement method to keep the JsonEditor translation namespace separate from the user translation one. With the ability to overload the TranslateElement method any way of translation can be applied externally to the json-editor.

### Sample

One Schema, but json-editor presented in English and German

![image](https://user-images.githubusercontent.com/48840279/103367957-a8266280-4ac6-11eb-81b0-67b04c34028f.png)

**Englisch Screen**

![image](https://user-images.githubusercontent.com/48840279/103368103-04898200-4ac7-11eb-9382-0cc96f082f09.png)

**German Screen**

![image](https://user-images.githubusercontent.com/48840279/103367636-e8391580-4ac5-11eb-8589-910ddf296118.png)

The translations happens outside the json-editor code using a JQuery.i18n, but keeping the json-editor messages separate from the user namespace definitions.

_For illustration_

```
  JSONEditor.defaults.translate = function (key, variables) {
    var text;
    if (key !== null) {
      text = $.i18n("edt_msg_" + key, variables);
    }
    return text;
  }; 

  JSONEditor.defaults.translateElement = function (key, variables) {
    var text;
    if (key !== null) {
        text = $.i18n(key, variables);
    }
    return text;
  };

```

