### PR TITLE
Close the properties modal when we click outside the modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /src/themes/*.css.js
 /src/editors/*.css.js
 /.vs
+**/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Fix for #900 to close the properties modal when we click outside modal
+
 ### 2.6.0
 
 - set show_opt_in per object editor

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -1042,9 +1042,8 @@ export class ObjectEditor extends AbstractEditor {
   }
 
   onOutsideModalClick (e) {
-    if (this.addproperty_holder &&
-      !this.addproperty_holder.contains(e.path[0] || e.composedPath()[0]) &&
-      this.adding_property) {
+    const path = e.path || (e.composedPath && e.composedPath())
+    if (this.addproperty_holder && !this.addproperty_holder.contains(path[0]) && this.adding_property) {
       e.preventDefault()
       e.stopPropagation()
       this.toggleAddProperty()

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -637,7 +637,7 @@ export class ObjectEditor extends AbstractEditor {
       this.addproperty_holder.appendChild(spacer)
 
       /* Close properties modal if clicked outside modal */
-      document.addEventListener('click', this.onOutsideModalClick)
+      document.addEventListener('click', this.onOutsideModalClick.bind(this))
 
       /* Description */
       if (this.schema.description) {

--- a/tests/codeceptjs/editors/object_test.js
+++ b/tests/codeceptjs/editors/object_test.js
@@ -259,6 +259,6 @@ Scenario('should open and close the properties modal', (I) => {
   I.seeElement('.json-editor-btn-edit_properties')
   I.click('.json-editor-btn-edit_properties')
   I.seeElement('.je-modal .property-selector')
-  I.click('.json-editor-btn-edit')
+  I.click('textarea')
   I.dontSeeElement('.je-modal .property-selector')
 })

--- a/tests/codeceptjs/editors/object_test.js
+++ b/tests/codeceptjs/editors/object_test.js
@@ -253,3 +253,12 @@ Scenario('should respect multiple dependency values', (I) => {
   I.selectOption('[name="root[answerA]"]', 'A')
   I.waitForVisible('[data-schemapath="root.answerB"] input', 5)
 })
+
+Scenario('should open and close the properties modal', (I) => {
+  I.amOnPage('object.html')
+  I.seeElement('.json-editor-btn-edit_properties')
+  I.click('.json-editor-btn-edit_properties')
+  I.seeElement('.je-modal .property-selector')
+  I.click('.json-editor-btn-edit')
+  I.dontSeeElement('.je-modal .property-selector')
+})


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | Yes
| New feature?  | No
| Breaks backward-compatibility?    | No
| Tests pass?   | Hopefully. The unit tests passed but the CodeceptJS tests did not.
| Fixed issues  | #900 
| Updated README/docs?   | Not required
| Added CHANGELOG entry?   | Yes

### Proposed Changes

- Bind `this` fix the modal closing
- Rework the event path to avoid an error outside of Chrome. `event.path` is not standard so `event.path[0]` throws a `ReferenceError`.
- I took a chance that you'd be OK with updating `.gitignore` and the docs. 🤞 

### Demo

![Demo #900](https://user-images.githubusercontent.com/2585460/105285668-d73e6a00-5b82-11eb-850f-d73232e053e0.gif)
