### PR TITLE
Replace property name in the error_required message with human readable property title

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -344,7 +344,7 @@ export class Validator {
             errors.push({
               path,
               property: 'required',
-              message: this.translate('error_required', [e])
+              message: this.translate('error_required', [schema && schema.properties[e] && schema.properties[e].title? schema.properties[e].title: e])
             })
           })
         }

--- a/src/validator.js
+++ b/src/validator.js
@@ -344,7 +344,7 @@ export class Validator {
             errors.push({
               path,
               property: 'required',
-              message: this.translate('error_required', [schema && schema.properties[e] && schema.properties[e].title? schema.properties[e].title: e])
+              message: this.translate('error_required', [schema && schema.properties[e] && schema.properties[e].title ? schema.properties[e].title: e])
             })
           })
         }

--- a/src/validator.js
+++ b/src/validator.js
@@ -344,7 +344,7 @@ export class Validator {
             errors.push({
               path,
               property: 'required',
-              message: this.translate('error_required', [schema && schema.properties[e] && schema.properties[e].title ? schema.properties[e].title : e])
+              message: this.translate('error_required', [schema && schema.properties && schema.properties[e] && schema.properties[e].title ? schema.properties[e].title : e])
             })
           })
         }

--- a/src/validator.js
+++ b/src/validator.js
@@ -344,7 +344,7 @@ export class Validator {
             errors.push({
               path,
               property: 'required',
-              message: this.translate('error_required', [schema && schema.properties[e] && schema.properties[e].title ? schema.properties[e].title: e])
+              message: this.translate('error_required', [schema && schema.properties[e] && schema.properties[e].title ? schema.properties[e].title : e])
             })
           })
         }


### PR DESCRIPTION
As user I want to see human-readable error message if a requierd property is not populated. 
Act: error text with the property name as the reference to the failure field
Exp: error test with the property title if exists or otherwise property  name, as the reference to the failure field

This problem is very actual for multi-language projects because user might be not able to match English name of the property and form field label on his own language.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
