### PR TITLE
Uniform Resource Name (URN) support for URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,11 @@ Here are all the available options:
     <td>If true default values based on the "type" of the property will be used</td>
     <td><code>true</code></td>
   </tr>
+  <tr>
+    <td>urn_resolver</td>
+    <td>A callback function to resolve an undefined Uniform Resource Name (URN) for <code>$ref</code>. The function receives a URN and callback to pass back a serialized JSON response. The function should return a boolean (true if the URN can be resolved; false otherwise).</td>
+    <td><code>false</code></td>
+  </tr>
   </tbody>
 </table>
 

--- a/tests/codeceptjs/schemaloader_test.js
+++ b/tests/codeceptjs/schemaloader_test.js
@@ -1,0 +1,13 @@
+var assert = require('assert');
+
+Feature('schemaloader');
+
+Scenario('resolving nested external URNs', async (I) => {
+  I.amOnPage('urn.html');
+  I.waitForElement('[data-schemapath="root"] h3', 10);
+  I.seeElementInDOM('[data-schemapath="root.fname"]')
+  I.seeElementInDOM('[data-schemapath="root.lname"]')
+
+  I.click('.get-value')
+  assert.equal(await I.grabValueFrom('.value'), '{"fname":"John","lname":"Doe"}');
+});

--- a/tests/pages/urn.html
+++ b/tests/pages/urn.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>URN</title>
+  <link rel="stylesheet" id="theme-link" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
+  <link rel="stylesheet" id="iconlib-link" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
+  <script src="https://cdn.jsdelivr.net/npm/mathjs@5.3.1/dist/math.min.js" class="external_mathjs"></script>
+  <script src="../../dist/jsoneditor.js"></script>
+</head>
+<body>
+
+<textarea class="value" cols="30" rows="10"></textarea>
+<button class='get-value'>Get Value</button>
+<button class='set-value'>Set Value</button>
+<div class='json-editor-container'></div>
+
+<script>
+  var jsonEditorContainer = document.querySelector('.json-editor-container');
+  var value = document.querySelector('.value');
+
+  var schema = {
+    $ref: 'urn:com:github:json-editor:name'
+  };
+
+  var editor = new JSONEditor(jsonEditorContainer, {
+    schema: schema,
+    theme: 'bootstrap4',
+    use_default_values: false,
+    show_errors: 'always',
+    urn_resolver: (urn, callback) => {
+      console.log('resolving ' + urn)
+      let schema
+
+      switch (urn) {
+        case 'urn:com:github:json-editor:name':
+          schema = {
+            type: 'object',
+            properties: {
+              fname: {
+                $ref: 'urn:com:github:json-editor:fname'
+              },
+              lname: {
+                $ref: 'urn:com:github:json-editor:lname#/definitions/lname'
+              }
+            }
+          }
+          break
+        case 'urn:com:github:json-editor:fname':
+          schema = {
+            id: 'urn:com:github:json-editor:fname',
+            type: 'string',
+            default: 'John',
+            minLength: 4
+          }
+          break
+	case 'urn:com:github:json-editor:lname':
+          schema = {
+            definitions: {
+              lname: {
+                id: 'urn:com:github:json-editor:lname',
+                type: 'string',
+                default: 'Doe',
+                minLength: 3
+              }
+            }
+          }
+          break
+        default: return false
+      }
+
+      // simulate async
+      window.setTimeout(() => {
+        callback(JSON.stringify(schema))
+      }, 500)
+
+      return true
+    }
+  })
+
+  document.querySelector('.get-value').addEventListener('click', function () {
+    value.value = JSON.stringify(editor.getValue())
+    console.log(editor.getValue())
+  })
+
+  document.querySelector('.set-value').addEventListener('click', function () {
+    editor.setValue({number_range: 2})
+  })
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #8, #622
| Updated README/docs?   | ✔️
| Added CHANGELOG entry?   | ❌

Add support for `$ref: 'urn:...'`. If the urn: is not declared locally, calls the `urn_resolver` callback.
 