### PR TITLE
fixes #922 - translate all buttons; translator no longer throws error…

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -29,204 +29,220 @@ languages.en = {
    */
   error_notset: 'Property must be set',
   /**
- * When a string must not be empty
- */
+  * When a string must not be empty
+  */
   error_notempty: 'Value required',
   /**
- * When a value is not one of the enumerated values
- */
+  * When a value is not one of the enumerated values
+  */
   error_enum: 'Value must be one of the enumerated values',
   /**
- * When a value doesn't validate any schema of a 'anyOf' combination
- */
+  * When a value doesn't validate any schema of a 'anyOf' combination
+  */
   error_anyOf: 'Value must validate against at least one of the provided schemas',
   /**
- * When a value doesn't validate
- * @variables This key takes one variable: The number of schemas the value does not validate
- */
+  * When a value doesn't validate
+  * @variables This key takes one variable: The number of schemas the value does not validate
+  */
   error_oneOf: 'Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.',
   /**
- * When a value does not validate a 'not' schema
- */
+  * When a value does not validate a 'not' schema
+  */
   error_not: 'Value must not validate against the provided schema',
   /**
- * When a value does not match any of the provided types
- */
+  * When a value does not match any of the provided types
+  */
   error_type_union: 'Value must be one of the provided types',
   /**
- * When a value does not match the given type
- * @variables This key takes one variable: The type the value should be of
- */
+  * When a value does not match the given type
+  * @variables This key takes one variable: The type the value should be of
+  */
   error_type: 'Value must be of type {{0}}',
   /**
- *  When the value validates one of the disallowed types
- */
+  *  When the value validates one of the disallowed types
+  */
   error_disallow_union: 'Value must not be one of the provided disallowed types',
   /**
- *  When the value validates a disallowed type
- * @variables This key takes one variable: The type the value should not be of
- */
+  *  When the value validates a disallowed type
+  * @variables This key takes one variable: The type the value should not be of
+  */
   error_disallow: 'Value must not be of type {{0}}',
   /**
- * When a value is not a multiple of or divisible by a given number
- * @variables This key takes one variable: The number mentioned above
- */
+  * When a value is not a multiple of or divisible by a given number
+  * @variables This key takes one variable: The number mentioned above
+  */
   error_multipleOf: 'Value must be a multiple of {{0}}',
   /**
- * When a value is greater than it's supposed to be (exclusive)
- * @variables This key takes one variable: The maximum
- */
+  * When a value is greater than it's supposed to be (exclusive)
+  * @variables This key takes one variable: The maximum
+  */
   error_maximum_excl: 'Value must be less than {{0}}',
   /**
- * When a value is greater than it's supposed to be (inclusive
- * @variables This key takes one variable: The maximum
- */
+  * When a value is greater than it's supposed to be (inclusive
+  * @variables This key takes one variable: The maximum
+  */
   error_maximum_incl: 'Value must be at most {{0}}',
   /**
- * When a value is lesser than it's supposed to be (exclusive)
- * @variables This key takes one variable: The minimum
- */
+  * When a value is lesser than it's supposed to be (exclusive)
+  * @variables This key takes one variable: The minimum
+  */
   error_minimum_excl: 'Value must be greater than {{0}}',
   /**
- * When a value is lesser than it's supposed to be (inclusive)
- * @variables This key takes one variable: The minimum
- */
+  * When a value is lesser than it's supposed to be (inclusive)
+  * @variables This key takes one variable: The minimum
+  */
   error_minimum_incl: 'Value must be at least {{0}}',
   /**
- * When a value have too many characters
- * @variables This key takes one variable: The maximum character count
- */
+  * When a value have too many characters
+  * @variables This key takes one variable: The maximum character count
+  */
   error_maxLength: 'Value must be at most {{0}} characters long',
   /**
- * When a value does not have enough characters
- * @variables This key takes one variable: The minimum character count
- */
+  * When a value does not have enough characters
+  * @variables This key takes one variable: The minimum character count
+  */
   error_minLength: 'Value must be at least {{0}} characters long',
   /**
- * When a value does not match a given pattern
- */
+  * When a value does not match a given pattern
+  */
   error_pattern: 'Value must match the pattern {{0}}',
   /**
- * When an array has additional items whereas it is not supposed to
- */
+  * When an array has additional items whereas it is not supposed to
+  */
   error_additionalItems: 'No additional items allowed in this array',
   /**
- * When there are to many items in an array
- * @variables This key takes one variable: The maximum item count
- */
+  * When there are to many items in an array
+  * @variables This key takes one variable: The maximum item count
+  */
   error_maxItems: 'Value must have at most {{0}} items',
   /**
- * When there are not enough items in an array
- * @variables This key takes one variable: The minimum item count
- */
+  * When there are not enough items in an array
+  * @variables This key takes one variable: The minimum item count
+  */
   error_minItems: 'Value must have at least {{0}} items',
   /**
- * When an array is supposed to have unique items but has duplicates
- */
+  * When an array is supposed to have unique items but has duplicates
+  */
   error_uniqueItems: 'Array must have unique items',
   /**
- * When there are too many properties in an object
- * @variables This key takes one variable: The maximum property count
- */
+  * When there are too many properties in an object
+  * @variables This key takes one variable: The maximum property count
+  */
   error_maxProperties: 'Object must have at most {{0}} properties',
   /**
- * When there are not enough properties in an object
- * @variables This key takes one variable: The minimum property count
- */
+  * When there are not enough properties in an object
+  * @variables This key takes one variable: The minimum property count
+  */
   error_minProperties: 'Object must have at least {{0}} properties',
   /**
- * When a required property is not defined
- * @variables This key takes one variable: The name of the missing property
- */
+  * When a required property is not defined
+  * @variables This key takes one variable: The name of the missing property
+  */
   error_required: "Object is missing the required property '{{0}}'",
   /**
- * When there is an additional property is set whereas there should be none
- * @variables This key takes one variable: The name of the additional property
- */
+  * When there is an additional property is set whereas there should be none
+  * @variables This key takes one variable: The name of the additional property
+  */
   error_additional_properties: 'No additional properties allowed, but property {{0}} is set',
   /**
- * When there is a propertyName that sets a max length and a property name exceeds the max length
- * @variables This key takes one variable: The name of the invalid property
- */
+  * When there is a propertyName that sets a max length and a property name exceeds the max length
+  * @variables This key takes one variable: The name of the invalid property
+  */
   error_property_names_exceeds_maxlength: 'Property name {{0}} exceeds maxLength',
   /**
- * When there is a propertyName that sets an enum and a property name matches none of the possible enum
- * @variables This key takes one variable: The name of the invalid property
- */
+  * When there is a propertyName that sets an enum and a property name matches none of the possible enum
+  * @variables This key takes one variable: The name of the invalid property
+  */
   error_property_names_enum_mismatch: 'Property name {{0}} does not match any enum values',
   /**
- * When there is a propertyName that sets a pattern and a property name does not match the pattern
- * @variables This key takes one variable: The name of the invalid property
- */
+  * When there is a propertyName that sets a pattern and a property name does not match the pattern
+  * @variables This key takes one variable: The name of the invalid property
+  */
   error_property_names_pattern_mismatch: 'Property name {{0}} does not match pattern',
   /**
- * When the propertyName is set to false and there is at least one property
- * @variables This key takes one variable: The name of the invalid property
- */
+  * When the propertyName is set to false and there is at least one property
+  * @variables This key takes one variable: The name of the invalid property
+  */
   error_property_names_false: 'Property name {{0}} fails when propertyName is false',
   /**
- * When the propertyName specifies a maxLength that is not a number
- * @variables This key takes one variable: The name of the current property
- */
+  * When the propertyName specifies a maxLength that is not a number
+  * @variables This key takes one variable: The name of the current property
+  */
   error_property_names_maxlength: 'Property name {{0}} cannot match invalid maxLength',
   /**
- * When the propertyName specifies an enum that is not an array
- * @variables This key takes one variable: The name of the current property
- */
+  * When the propertyName specifies an enum that is not an array
+  * @variables This key takes one variable: The name of the current property
+  */
   error_property_names_enum: 'Property name {{0}} cannot match invalid enum',
   /**
- * When the propertyName specifies a pattern that is not a string
- * @variables This key takes one variable: The name of the current property
- */
+  * When the propertyName specifies a pattern that is not a string
+  * @variables This key takes one variable: The name of the current property
+  */
   error_property_names_pattern: 'Property name {{0}} cannot match invalid pattern',
   /**
- * When the propertyName is unsupported
- * @variables This key takes one variable: The name of the invalid propertyName
- */
+  * When the propertyName is unsupported
+  * @variables This key takes one variable: The name of the invalid propertyName
+  */
   error_property_names_unsupported: 'Unsupported propertyName {{0}}',
   /**
- * When a dependency is not resolved
- * @variables This key takes one variable: The name of the missing property for the dependency
- */
+  * When a dependency is not resolved
+  * @variables This key takes one variable: The name of the missing property for the dependency
+  */
   error_dependency: 'Must have property {{0}}',
   /**
- * When a date is in incorrect format
- * @variables This key takes one variable: The valid format
- */
+  * When a date is in incorrect format
+  * @variables This key takes one variable: The valid format
+  */
   error_date: 'Date must be in the format {{0}}',
   /**
- * When a time is in incorrect format
- * @variables This key takes one variable: The valid format
- */
+  * When a time is in incorrect format
+  * @variables This key takes one variable: The valid format
+  */
   error_time: 'Time must be in the format {{0}}',
   /**
- * When a datetime-local is in incorrect format
- * @variables This key takes one variable: The valid format
- */
+  * When a datetime-local is in incorrect format
+  * @variables This key takes one variable: The valid format
+  */
   error_datetime_local: 'Datetime must be in the format {{0}}',
   /**
- * When a integer date is less than 1 January 1970
- */
+  * When a integer date is less than 1 January 1970
+  */
   error_invalid_epoch: 'Date must be greater than 1 January 1970',
   /**
- * When an IPv4 is in incorrect format
- */
+  * When an IPv4 is in incorrect format
+  */
   error_ipv4: 'Value must be a valid IPv4 address in the form of 4 numbers between 0 and 255, separated by dots',
   /**
- * When an IPv6 is in incorrect format
- */
+  * When an IPv6 is in incorrect format
+  */
   error_ipv6: 'Value must be a valid IPv6 address',
   /**
- * When a hostname is in incorrect format
- */
+  * When a hostname is in incorrect format
+  */
   error_hostname: 'The hostname has the wrong format',
   /**
- * Text on Delete All buttons
- */
+  * Text/Title on Save button
+  */
+  button_save: 'Save',
+  /**
+  * Text/Title on Copy button
+  */
+  button_copy: 'Copy',
+  /**
+  * Text/Title on Cancel button
+  */
+  button_cancel: 'Cancel',
+  /**
+  * Text/Title on Add button
+  */
+  button_add: 'Add',
+  /**
+  * Text on Delete All buttons
+  */
   button_delete_all: 'All',
   /**
- * Title on Delete All buttons
- */
+  * Title on Delete All buttons
+  */
   button_delete_all_title: 'Delete All',
   /**
   * Text on Delete Last buttons
@@ -252,9 +268,18 @@ languages.en = {
   */
   button_move_up_title: 'Move up',
   /**
+  * Text on Object Properties buttons
+  */
+  button_properties: 'Properties',
+  /**
   * Title on Object Properties buttons
   */
   button_object_properties: 'Object Properties',
+  /**
+  * Title on Copy Row button
+  * @variable This key takes one variable: The title of object to delete
+  */
+  button_copy_row_title: 'Copy {{0}}',
   /**
   * Title on Delete Row buttons
   * @variable This key takes one variable: The title of object to delete
@@ -276,6 +301,14 @@ languages.en = {
   * Title on Expand buttons
   */
   button_expand: 'Expand',
+  /**
+  * Title on Edit JSON buttons
+  */
+  button_edit_json: 'Edit JSON',
+  /**
+  * Text/Title on Upload buttons
+  */
+  button_upload: 'Upload',
   /**
   * Title on Flatpickr toggle buttons
   */
@@ -311,9 +344,7 @@ function translate (key, variables) {
   const lang = defaults.languages[defaults.language]
   if (!lang) throw new Error(`Unknown language ${defaults.language}`)
 
-  let string = lang[key] || defaults.languages[default_language][key]
-
-  if (typeof string === 'undefined') throw new Error(`Unknown translate string ${key}`)
+  let string = lang[key] || defaults.languages[default_language][key] || key
 
   if (variables) {
     for (let i = 0; i < variables.length; i++) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -293,10 +293,13 @@ export class AbstractEditor {
 
   onMove () {}
 
-  getButton (text, icon, title) {
+  getButton (text, icon, title, args = []) {
     const btnClass = `json-editor-btn-${icon}`
     if (!this.iconlib) icon = null
     else icon = this.iconlib.getIcon(icon)
+
+    text = this.translate(text, args)
+    title = this.translate(title, args)
 
     if (!icon && title) {
       text = title
@@ -308,9 +311,12 @@ export class AbstractEditor {
     return btn
   }
 
-  setButtonText (button, text, icon, title) {
+  setButtonText (button, text, icon, title, args = []) {
     if (!this.iconlib) icon = null
     else icon = this.iconlib.getIcon(icon)
+
+    text = this.translate(text, args)
+    title = this.translate(title, args)
 
     if (!icon && title) {
       text = title

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -499,7 +499,7 @@ export class ArrayEditor extends AbstractEditor {
   }
 
   _createDeleteButton (i, holder) {
-    const button = this.getButton(this.getItemTitle(), 'delete', this.translate('button_delete_row_title', [this.getItemTitle()]))
+    const button = this.getButton(this.getItemTitle(), 'delete', 'button_delete_row_title', [this.getItemTitle()])
     button.classList.add('delete', 'json-editor-btntype-delete')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {
@@ -540,7 +540,7 @@ export class ArrayEditor extends AbstractEditor {
   }
 
   _createCopyButton (i, holder) {
-    const button = this.getButton(this.getItemTitle(), 'copy', `Copy ${this.getItemTitle()}`)
+    const button = this.getButton(this.getItemTitle(), 'copy', 'button_copy_row_title', [this.getItemTitle()])
     button.classList.add('copy', 'json-editor-btntype-copy')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {
@@ -565,7 +565,7 @@ export class ArrayEditor extends AbstractEditor {
   }
 
   _createMoveUpButton (i, holder) {
-    const button = this.getButton('', (this.schema.format === 'tabs-top' ? 'moveleft' : 'moveup'), this.translate('button_move_up_title'))
+    const button = this.getButton('', (this.schema.format === 'tabs-top' ? 'moveleft' : 'moveup'), 'button_move_up_title')
     button.classList.add('moveup', 'json-editor-btntype-move')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {
@@ -595,7 +595,7 @@ export class ArrayEditor extends AbstractEditor {
   }
 
   _createMoveDownButton (i, holder) {
-    const button = this.getButton('', (this.schema.format === 'tabs-top' ? 'moveright' : 'movedown'), this.translate('button_move_down_title'))
+    const button = this.getButton('', (this.schema.format === 'tabs-top' ? 'moveright' : 'movedown'), 'button_move_down_title')
     button.classList.add('movedown', 'json-editor-btntype-move')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {
@@ -652,7 +652,7 @@ export class ArrayEditor extends AbstractEditor {
   }
 
   _createToggleButton () {
-    const button = this.getButton('', 'collapse', this.translate('button_collapse'))
+    const button = this.getButton('', 'collapse', 'button_collapse')
     button.classList.add('json-editor-btntype-toggle')
     this.title.insertBefore(button, this.title.childNodes[0])
 
@@ -667,19 +667,19 @@ export class ArrayEditor extends AbstractEditor {
         this.collapsed = false
         this.row_holder.style.display = rowHolderDisplay
         this.controls.style.display = controlsDisplay
-        this.setButtonText(e.currentTarget, '', 'collapse', this.translate('button_collapse'))
+        this.setButtonText(e.currentTarget, '', 'collapse', 'button_collapse')
       } else {
         this.collapsed = true
         this.row_holder.style.display = 'none'
         this.controls.style.display = 'none'
-        this.setButtonText(e.currentTarget, '', 'expand', this.translate('button_expand'))
+        this.setButtonText(e.currentTarget, '', 'expand', 'button_expand')
       }
     })
     return button
   }
 
   _createAddRowButton () {
-    const button = this.getButton(this.getItemTitle(), 'add', this.translate('button_add_row_title', [this.getItemTitle()]))
+    const button = this.getButton(this.getItemTitle(), 'add', 'button_add_row_title', [this.getItemTitle()])
     button.classList.add('json-editor-btntype-add')
     button.addEventListener('click', (e) => {
       e.preventDefault()
@@ -706,7 +706,7 @@ export class ArrayEditor extends AbstractEditor {
   }
 
   _createDeleteLastRowButton () {
-    const button = this.getButton(this.translate('button_delete_last', [this.getItemTitle()]), 'subtract', this.translate('button_delete_last_title', [this.getItemTitle()]))
+    const button = this.getButton('button_delete_last', 'subtract', 'button_delete_last_title', [this.getItemTitle()])
     button.classList.add('json-editor-btntype-deletelast')
     button.addEventListener('click', (e) => {
       e.preventDefault()
@@ -740,7 +740,7 @@ export class ArrayEditor extends AbstractEditor {
   }
 
   _createRemoveAllRowsButton () {
-    const button = this.getButton(this.translate('button_delete_all'), 'delete', this.translate('button_delete_all_title'))
+    const button = this.getButton('button_delete_all', 'delete', 'button_delete_all_title')
     button.classList.add('json-editor-btntype-deleteall')
     button.addEventListener('click', (e) => {
       e.preventDefault()

--- a/src/editors/datetime.js
+++ b/src/editors/datetime.js
@@ -51,13 +51,13 @@ export class DatetimeEditor extends StringEditor {
         /* Create buttons for input group */
         const buttons = []
         if (this.options.flatpickr.showToggleButton !== false) {
-          const toggleButton = this.getButton('', this.schema.format === 'time' ? 'time' : 'calendar', this.translate('flatpickr_toggle_button'))
+          const toggleButton = this.getButton('', this.schema.format === 'time' ? 'time' : 'calendar', 'flatpickr_toggle_button')
           /* Attribute for flatpicker */
           toggleButton.setAttribute('data-toggle', '')
           buttons.push(toggleButton)
         }
         if (this.options.flatpickr.showClearButton !== false) {
-          const clearButton = this.getButton('', 'clear', this.translate('flatpickr_clear_button'))
+          const clearButton = this.getButton('', 'clear', 'flatpickr_clear_button')
           /* Attribute for flatpicker */
           clearButton.setAttribute('data-clear', '')
           buttons.push(clearButton)

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -568,21 +568,21 @@ export class ObjectEditor extends AbstractEditor {
       this.editjson_holder = this.theme.getModal()
       this.editjson_textarea = this.theme.getTextareaInput()
       this.editjson_textarea.classList.add('je-edit-json--textarea')
-      this.editjson_save = this.getButton('Save', 'save', 'Save')
+      this.editjson_save = this.getButton('button_save', 'save', 'button_save')
       this.editjson_save.classList.add('json-editor-btntype-save')
       this.editjson_save.addEventListener('click', (e) => {
         e.preventDefault()
         e.stopPropagation()
         this.saveJSON()
       })
-      this.editjson_copy = this.getButton('Copy', 'copy', 'Copy')
+      this.editjson_copy = this.getButton('button_copy', 'copy', 'button_copy')
       this.editjson_copy.classList.add('json-editor-btntype-copy')
       this.editjson_copy.addEventListener('click', (e) => {
         e.preventDefault()
         e.stopPropagation()
         this.copyJSON()
       })
-      this.editjson_cancel = this.getButton('Cancel', 'cancel', 'Cancel')
+      this.editjson_cancel = this.getButton('button_cancel', 'cancel', 'button_cancel')
       this.editjson_cancel.classList.add('json-editor-btntype-cancel')
       this.editjson_cancel.addEventListener('click', (e) => {
         e.preventDefault()
@@ -598,7 +598,7 @@ export class ObjectEditor extends AbstractEditor {
       this.addproperty_holder = this.theme.getModal()
       this.addproperty_list = document.createElement('div')
       this.addproperty_list.classList.add('property-selector')
-      this.addproperty_add = this.getButton('add', 'add', 'add')
+      this.addproperty_add = this.getButton('button_add', 'add', 'button_add')
       this.addproperty_add.classList.add('json-editor-btntype-add')
 
       this.addproperty_input = this.theme.getFormInputField('text')
@@ -711,7 +711,7 @@ export class ObjectEditor extends AbstractEditor {
 
       /* Show/Hide button */
       this.collapsed = false
-      this.collapse_control = this.getButton('', 'collapse', this.translate('button_collapse'))
+      this.collapse_control = this.getButton('', 'collapse', 'button_collapse')
       this.collapse_control.classList.add('json-editor-btntype-toggle')
       this.title.insertBefore(this.collapse_control, this.title.childNodes[0])
 
@@ -721,11 +721,11 @@ export class ObjectEditor extends AbstractEditor {
         if (this.collapsed) {
           this.editor_holder.style.display = ''
           this.collapsed = false
-          this.setButtonText(this.collapse_control, '', 'collapse', this.translate('button_collapse'))
+          this.setButtonText(this.collapse_control, '', 'collapse', 'button_collapse')
         } else {
           this.editor_holder.style.display = 'none'
           this.collapsed = true
-          this.setButtonText(this.collapse_control, '', 'expand', this.translate('button_expand'))
+          this.setButtonText(this.collapse_control, '', 'expand', 'button_expand')
         }
       })
 
@@ -742,7 +742,7 @@ export class ObjectEditor extends AbstractEditor {
       }
 
       /* Edit JSON Button */
-      this.editjson_control = this.getButton('JSON', 'edit', 'Edit JSON')
+      this.editjson_control = this.getButton('JSON', 'edit', 'button_edit_json')
       this.editjson_control.classList.add('json-editor-btntype-editjson')
       this.editjson_control.addEventListener('click', (e) => {
         e.preventDefault()
@@ -760,7 +760,7 @@ export class ObjectEditor extends AbstractEditor {
       }
 
       /* Object Properties Button */
-      this.addproperty_button = this.getButton('Properties', 'edit_properties', this.translate('button_object_properties'))
+      this.addproperty_button = this.getButton('properties', 'edit_properties', 'button_object_properties')
       this.addproperty_button.classList.add('json-editor-btntype-properties')
       this.addproperty_button.addEventListener('click', (e) => {
         e.preventDefault()

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -311,7 +311,7 @@ export class TableEditor extends ArrayEditor {
   }
 
   _createDeleteButton (i, holder) {
-    const button = this.getButton('', 'delete', this.translate('button_delete_row_title_short'))
+    const button = this.getButton('', 'delete', 'button_delete_row_title_short')
     button.classList.add('delete', 'json-editor-btntype-delete')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {
@@ -336,7 +336,7 @@ export class TableEditor extends ArrayEditor {
   }
 
   _createCopyButton (i, holder) {
-    const button = this.getButton('', 'copy', this.translate('button_copy_row_title_short'))
+    const button = this.getButton('', 'copy', 'button_copy_row_title_short')
     button.classList.add('copy', 'json-editor-btntype-copy')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {
@@ -356,7 +356,7 @@ export class TableEditor extends ArrayEditor {
   }
 
   _createMoveUpButton (i, holder) {
-    const button = this.getButton('', 'moveup', this.translate('button_move_up_title'))
+    const button = this.getButton('', 'moveup', 'button_move_up_title')
     button.classList.add('moveup', 'json-editor-btntype-move')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {
@@ -377,7 +377,7 @@ export class TableEditor extends ArrayEditor {
   }
 
   _createMoveDownButton (i, holder) {
-    const button = this.getButton('', 'movedown', this.translate('button_move_down_title'))
+    const button = this.getButton('', 'movedown', 'button_move_down_title')
     button.classList.add('movedown', 'json-editor-btntype-move')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {
@@ -409,10 +409,10 @@ export class TableEditor extends ArrayEditor {
         this.setVisibility(this.panel, this.collapsed)
         if (this.collapsed) {
           this.collapsed = false
-          this.setButtonText(e.currentTarget, '', 'collapse', this.translate('button_collapse'))
+          this.setButtonText(e.currentTarget, '', 'collapse', 'button_collapse')
         } else {
           this.collapsed = true
-          this.setButtonText(e.currentTarget, '', 'expand', this.translate('button_expand'))
+          this.setButtonText(e.currentTarget, '', 'expand', 'button_expand')
         }
       })
 
@@ -436,13 +436,13 @@ export class TableEditor extends ArrayEditor {
   }
 
   _createToggleButton () {
-    const button = this.getButton('', 'collapse', this.translate('button_collapse'))
+    const button = this.getButton('', 'collapse', 'button_collapse')
     button.classList.add('json-editor-btntype-toggle')
     return button
   }
 
   _createAddRowButton () {
-    const button = this.getButton(this.getItemTitle(), 'add', this.translate('button_add_row_title', [this.getItemTitle()]))
+    const button = this.getButton(this.getItemTitle(), 'add', 'button_add_row_title', [this.getItemTitle()])
     button.classList.add('json-editor-btntype-add')
     button.addEventListener('click', (e) => {
       e.preventDefault()
@@ -459,7 +459,7 @@ export class TableEditor extends ArrayEditor {
   }
 
   _createDeleteLastRowButton () {
-    const button = this.getButton(this.translate('button_delete_last', [this.getItemTitle()]), 'subtract', this.translate('button_delete_last_title', [this.getItemTitle()]))
+    const button = this.getButton('button_delete_last', 'subtract', 'button_delete_last_title', [this.getItemTitle()])
     button.classList.add('json-editor-btntype-deletelast')
     button.addEventListener('click', (e) => {
       e.preventDefault()
@@ -480,7 +480,7 @@ export class TableEditor extends ArrayEditor {
   }
 
   _createRemoveAllRowsButton () {
-    const button = this.getButton(this.translate('button_delete_all'), 'delete', this.translate('button_delete_all_title'))
+    const button = this.getButton('button_delete_all', 'delete', 'button_delete_all_title')
     button.classList.add('json-editor-btntype-deleteall')
     button.addEventListener('click', (e) => {
       e.preventDefault()

--- a/src/editors/upload.js
+++ b/src/editors/upload.js
@@ -216,7 +216,7 @@ export class UploadEditor extends AbstractEditor {
       file.formattedSize = `${parseFloat((file.size / (1024 ** i)).toFixed(2))} ${['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'][i]}`
     } else file.formattedSize = '0 Bytes'
 
-    const uploadButton = this.getButton('Upload', 'upload', 'Upload')
+    const uploadButton = this.getButton('button_upload', 'upload', 'button_upload')
     uploadButton.addEventListener('click', (event) => {
       event.preventDefault()
 

--- a/tests/unit/defaults.spec.js
+++ b/tests/unit/defaults.spec.js
@@ -32,7 +32,7 @@ describe('languages test', () => {
     expect(defaults.translate('error_notempty')).toBe('Value required')
   })
 
-  it('throw error to unknown translate string', () => {
-    expect(() => defaults.translate('unknown_message')).toThrow()
+  it('should return translation key for unknown translation string', () => {
+    expect(defaults.translate('unknown_message')).toBe('unknown_message')
   })
 })


### PR DESCRIPTION
… for unknown translation keys

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #922
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
