### PR TITLE
bugfix: 0 in integer array shows empty when use_default_values=false …

### DIFF
--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -316,7 +316,7 @@ export class TableEditor extends ArrayEditor {
       this.rows[i].movedown_button = this._createMoveDownButton(i, controlsHolder)
     }
 
-    if (value) this.rows[i].setValue(value)
+    if (value != null) this.rows[i].setValue(value)
   }
 
   _createDeleteButton (i, holder) {


### PR DESCRIPTION
…and remove_empty_properties=true

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️❌
| Tests pass?   | n.a.
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

Solve bug:
Version: 2.3~2.5.3
Reproduce step: 
show an simple array like the following code:
```javascript
      var editor = new JSONEditor(document.getElementById('editor_holder'),{
        schema: {
          type: "object",
          title: "root",
          properties: {
            ranges: {
              type: "array",
              format: "table",
              items: {
                type: "integer"
              }
            }
          }
        },
        startval: {
          ranges: [0,1,2],
        },
        remove_empty_properties: true,
        use_default_values: false
      });
```
Expected:  show array element 0, 1, 2.
Actual: show emply, 1, 2
