### PR TITLE
Option for editing of undefined non-required fields

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -1203,7 +1203,7 @@ export class ObjectEditor extends AbstractEditor {
         editor.setValue(value[i], initial)
         editor.activate()
         /* Otherwise, remove value unless this is the initial set or it's required */
-      } else if (!initial && !this.isRequiredObject(editor)) {
+      } else if (!initial && !this.isRequiredObject(editor) && !this.options.show_non_required_editors) {
         if (this.jsoneditor.options.show_opt_in || this.options.show_opt_in) {
           editor.deactivate()
         } else {


### PR DESCRIPTION
As developer I want to let user edit (set, update) optional fields if future even if inital value was empty. 

Reproduce:
1) User creates new object A.
2) User sets only mandatory fields and keep optional fields blank.
3) User saves object.
4) User decided to set optional filed of A. He starts editing orbject A
Current behavior:
 5) Json-editor is not displaying editor for optional filed beacuse it is not initial object creation and optional field value is undefined.
Expected behaviour:
 6) Json-editor displayes editor with empty value for optional field.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
