### PR TITLE
Read-only base64 images should respect enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - pass additional pathDepth parameter to getHeader() to allow themes to render headings hierarchically
 - add Open Iconic iconlib
 - switched CI to Github Actions
+- read-only base64 editors respect enum values when calling setValue()
 
 ### 2.5.3
 

--- a/src/editors/base64.js
+++ b/src/editors/base64.js
@@ -138,7 +138,8 @@ export class Base64Editor extends AbstractEditor {
 
   setValue (val) {
     if (this.value !== val) {
-      this.value = val
+      if (this.schema.readOnly && this.schema.enum && !this.schema.enum.includes(val)) this.value = this.schema.enum[0]
+      else this.value = val
       this.input.value = this.value
       this.refreshPreview()
       this.onChange()


### PR DESCRIPTION
If using enum to provide a default value that is read-only, `setValue` should respect the enum rather than overriding it when `keep_values` is enabled.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | N/A
| Added CHANGELOG entry?   | ✔️
