### PR TITLE
Add accessibility support for inputs of type "string"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - switched CI to Github Actions
 - read-only base64 editors respect enum values when calling setValue()
 
+### 2.5.4
+
+- fixes #997 add accessibility support for string input types
+
 ### 2.5.3
 
 - fix oneOf and anyOf error messages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-editor/json-editor",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@json-editor/json-editor",
   "title": "JSONEditor",
   "description": "JSON Schema based editor",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "main": "dist/jsoneditor.js",
   "author": {
     "name": "Jeremy Dorn",

--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -6,12 +6,14 @@ export class StringEditor extends AbstractEditor {
     super.register()
     if (!this.input) return
     this.input.setAttribute('name', this.formname)
+    this.input.setAttribute('aria-label', this.formname)
   }
 
   unregister () {
     super.unregister()
     if (!this.input) return
     this.input.removeAttribute('name')
+    this.input.removeAttribute('aria-label')
   }
 
   setValue (value, initial, fromTemplate) {
@@ -201,7 +203,7 @@ export class StringEditor extends AbstractEditor {
       input = this.theme.getRangeControl(this.input, this.theme.getRangeOutput(this.input, this.schema.default || Math.max(this.schema.minimum || 0, 0)))
     }
 
-    this.control = this.theme.getFormControl(this.label, input, this.description, this.infoButton)
+    this.control = this.theme.getFormControl(this.label, input, this.description, this.infoButton, this.formname)
     this.container.appendChild(this.control)
 
     /* Any special formatting that needs to happen after the input is added to the dom */

--- a/src/theme.js
+++ b/src/theme.js
@@ -330,7 +330,7 @@ export class AbstractTheme {
     el.classList.add('form-control')
     if (label) {
       el.appendChild(label)
-      if (formName) label.setAttribute('for', formName);
+      if (formName) label.setAttribute('for', formName)
     }
     if ((input.type === 'checkbox' || input.type === 'radio') && label) {
       input.style.width = 'auto'

--- a/src/theme.js
+++ b/src/theme.js
@@ -325,10 +325,13 @@ export class AbstractTheme {
 
   }
 
-  getFormControl (label, input, description, infoText) {
+  getFormControl (label, input, description, infoText, formName) {
     const el = document.createElement('div')
     el.classList.add('form-control')
-    if (label) el.appendChild(label)
+    if (label) {
+      el.appendChild(label)
+      if (formName) label.setAttribute('for', formName);
+    }
     if ((input.type === 'checkbox' || input.type === 'radio') && label) {
       input.style.width = 'auto'
       label.insertBefore(input, label.firstChild)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #997 
| Updated README/docs?   | ✔️
| Added CHANGELOG entry?   | ✔️

## What does this PR contains?
I simply added an aria-label for lone inputs as per [w3.org](https://www.w3.org/WAI/tutorials/forms/labels/#hiding-label-text).  
For inputs with already existing labels, I added a `for` attribute binded with an id added on the input.

This fixes the accessibility issues for string inputs.  
  
I did not update the tests because there aren't that many changes and I don't see what there is to test but they do pass though. Let me know if I should update them one way or another.