### PR TITLE
Fix bug in validator.fitTest where anyOf schemata were not handled co…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 - add Open Iconic iconlib
 - switched CI to Github Actions
 - read-only base64 editors respect enum values when calling setValue()
+- fix bug in validator.fitTest where anyOf schemata were not handled correctly
 
 ### 2.5.4
 
 - fixes #997 add accessibility support for string input types
-- fix bug in validator.fitTest where anyOf schemata were not handled correctly
 
 ### 2.5.3
 
@@ -76,7 +76,7 @@
 - Fix of #701 - editors/number.js and editors/integer.js don't change values when validation is failed
 - Fix of #716 - add ignore for allOf to fall in line with existing ignores of anyOf/oneOf for additionalProperties validation
 - Fix of #714 - Checkboxes inside object tables duplicate labels from heading
-- Added copy button to arrays in table format 
+- Added copy button to arrays in table format
 
 ### 2.1.0
  - fixed vulnerability in "http-server" package (origin/feature/merges-20200227, feature/merges-20200227) - using latest node LTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### 2.5.4
 
 - fixes #997 add accessibility support for string input types
+- fix bug in validator.fitTest where anyOf schemata were not handled correctly
 
 ### 2.5.3
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "cssnano": "^4.1.11",
     "eslint": "^6.8.0",
     "eslint-loader": "^2.2.1",
+    "fast-deep-equal": "^3.1.3",
     "http-server": "^0.12.3",
     "jasmine": "^3.7.0",
     "jasmine-core": "^3.7.1",

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -993,7 +993,8 @@ export class ObjectEditor extends AbstractEditor {
       this.editors[name].register()
       /* New property */
     } else {
-      if (!this.canHaveAdditionalProperties() && (!this.schema.properties || !this.schema.properties[name])) {
+      if (!this.canHaveAdditionalProperties() && (!this.schema.properties || !this.schema.properties[name]) &&
+        (!this.schema.patternProperties || !(Object.keys(this.schema.patternProperties).find(i => new RegExp(i).test(name))))) {
         return
       }
 

--- a/src/validator.js
+++ b/src/validator.js
@@ -527,20 +527,35 @@ export class Validator {
     const fit = { match: 0, extra: 0 }
     if (typeof value === 'object' && value !== null) {
       /* Work on a copy of the schema */
-      const properties = this._getSchema(givenSchema).properties
-
-      for (const i in properties) {
-        if (!hasOwnProperty(properties, i)) {
-          fit.extra += weight
-          continue
+      const schema = this._getSchema(givenSchema)
+      /* If the schema is an anyOf declaration, do use the properties of the allowed sub schemata instead.
+      Of these sub schemata, the best fit is selected */
+      if (schema.anyOf) {
+        let bestFit = { ...fit }
+        for (const subSchema of schema.anyOf) {
+          const subFit = this.fitTest(value, subSchema, weight)
+          /* The best fit is the one with the best value for match. If there are multiple results
+          with the same match value, use the one with the least number of extra properties */
+          if ((subFit.match > bestFit.match) || (subFit.match === bestFit.match && subFit.extra < bestFit.extra)) {
+            bestFit = subFit
+          }
         }
-        if (typeof value[i] === 'object' && typeof properties[i] === 'object' && typeof properties[i].properties === 'object') {
-          const result = this.fitTest(value[i], properties[i], weight / 100)
-          fit.match += result.match
-          fit.extra += result.extra
-        }
-        if (typeof value[i] !== 'undefined') {
-          fit.match += weight
+        return bestFit
+      } else {
+        const properties = this._getSchema(givenSchema).properties
+        for (const i in properties) {
+          if (!hasOwnProperty(properties, i)) {
+            fit.extra += weight
+            continue
+          }
+          if (typeof value[i] === 'object' && typeof properties[i] === 'object' && typeof properties[i].properties === 'object') {
+            const result = this.fitTest(value[i], properties[i], weight / 100)
+            fit.match += result.match
+            fit.extra += result.extra
+          }
+          if (typeof value[i] !== 'undefined') {
+            fit.match += weight
+          }
         }
       }
     }

--- a/tests/codeceptjs/editors/validation_test.js
+++ b/tests/codeceptjs/editors/validation_test.js
@@ -6,7 +6,7 @@ Feature('Validations')
 
 Scenario('test validations in validation.html', (I) => {
   I.amOnPage('validation.html')
-  var numberOfTestItemsExpected = 155
+  var numberOfTestItemsExpected = 156
   I.waitForElement('#output div:nth-child(' + numberOfTestItemsExpected + ')', 10)
   I.seeNumberOfElements('#output div', numberOfTestItemsExpected)
   I.see('success')

--- a/tests/codeceptjs/editors/validation_test.js
+++ b/tests/codeceptjs/editors/validation_test.js
@@ -6,7 +6,7 @@ Feature('Validations')
 
 Scenario('test validations in validation.html', (I) => {
   I.amOnPage('validation.html')
-  var numberOfTestItemsExpected = 152
+  var numberOfTestItemsExpected = 155
   I.waitForElement('#output div:nth-child(' + numberOfTestItemsExpected + ')', 10)
   I.seeNumberOfElements('#output div', numberOfTestItemsExpected)
   I.see('success')

--- a/tests/fixtures/validation.json
+++ b/tests/fixtures/validation.json
@@ -1136,5 +1136,112 @@
                "charlie": { "type": "string" }
            }
         ]
+    },
+    "nested_anyOf": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "prop": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/A"
+              },
+              {
+                "$ref": "#/definitions/B"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "A": {
+            "title": "A",
+            "type": "object",
+            "properties": {
+              "fooA": {
+                "type": "string"
+              },
+              "barA": {
+                "type": "string"
+              },
+              "common": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "fooA",
+              "barA"
+            ]
+          },
+          "B": {
+            "title": "B",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/C"
+              },
+              {
+                "$ref": "#/definitions/D"
+              }
+            ]
+          },
+          "C": {
+            "title": "C",
+            "type": "object",
+            "properties": {
+              "fooC": {
+                "type": "string"
+              },
+              "barC": {
+                "type": "string"
+              },
+              "common": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "fooC",
+              "barC"
+            ]
+          },
+          "D": {
+            "title": "D",
+            "type": "object",
+            "properties": {
+              "fooD": {
+                "type": "string"
+              },
+              "barD": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "fooD",
+              "barD"
+            ]
+          }
+        }
+      },
+      "valid": [
+        {
+          "prop": {
+            "fooC": "foo",
+            "barC": "bar",
+            "common": "common"
+          }
+        },
+        {
+          "prop": {
+            "fooA": "foo",
+            "barA": "bar",
+            "common": "common"
+          }
+        }
+      ],
+      "invalid": [
+        {
+          "prop": {
+            "common": "common"
+          }
+        }
+      ]
     }
 }

--- a/tests/fixtures/validation.json
+++ b/tests/fixtures/validation.json
@@ -1230,6 +1230,13 @@
         },
         {
           "prop": {
+            "fooD": "foo",
+            "barD": "bar",
+            "common": "common"
+          }
+        },
+        {
+          "prop": {
             "fooA": "foo",
             "barA": "bar",
             "common": "common"

--- a/tests/unit/validator.spec.js
+++ b/tests/unit/validator.spec.js
@@ -8,6 +8,7 @@ import fixtureString from '../fixtures/string.json'
 import fixtureRecursive from '../fixtures/recursive.json'
 import * as math from 'mathjs'
 import { createFakeServer } from 'sinon'
+import * as deepEqual from 'fast-deep-equal';
 
 describe('Validator', () => {
   it('mathjs test', () => {
@@ -79,6 +80,15 @@ describe('Validation Test', () => {
             done()
           })
         })
+
+        it(`does not change valid data ${i + 1}`, (done) => {
+          editor.on('ready', () => {
+            editor.setValue(v)
+            expect(deepEqual(editor.getValue(), v)).toBe(true)
+            done()
+          })
+        })
+
       })
       spec.invalid.forEach((v, i) => {
         it(`invalid data ${i + 1}`, (done) => {


### PR DESCRIPTION
Fix bug in validator.fitTest where anyOf schemata were not handled correctly

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  |  -
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️

We use json-editor with a schema which roughly looks like this:
```
{
    "definitions": {
        "prop": {
            "anyOf": [
                {
                    "$ref": "#/definitions/A"
                },
                {
                    "$ref": "#/definitions/B"
                }
            ]
        },
        "A": {
            "type": "object",
            "properties": {
                "fooA": {
                    "type": "string"
                },
                "barA": {
                    "type": "string"
                },
                "common": {
                    "type": "string"
                }
            },
            "required": [
                "fooA",
                "barA"
            ]
        },
        "B": {
            "anyOf": [
                {
                    "$ref": "#/definitions/C"
                },
                {
                    "$ref": "#/definitions/D"
                }
            ]
        },
        "C": {
            "type": "object",
            "properties": {
                "fooC": {
                    "type": "string"
                },
                "barC": {
                    "type": "string"
                },
                "common": {
                    "type": "string"
                }
            },
            "required": [
                "fooD",
                "barD"
            ]
        },
        "D": {
            "type": "object",
            "properties": {
                "fooD": {
                    "type": "string"
                },
                "barD": {
                    "type": "string"
                }
            },
            "required": [
                "fooD",
                "barD"
            ]
        }
    }
}

```
We consider the following value to be matched against this schema:
```
{
    "fooC": "test",
    "barC": "test",
    "common": "test"
}
```
The expected behavior would be that `B` is deemed the correct schema for the test value because the test value matches schema `C` which is listed as an `anyOf` option for `B`.

The old implementation of `fitTest` ignores the nested properties of `B` (because `B` itself has no properties). Because we are in an `anyOf` scenario, the `multiple` editor then replaces the previously correctly identified schema (B) by the one with the best `fitTest` result (see https://github.com/json-editor/json-editor/blob/c9a9196d6643e9a05d979093dde0a0332c15bfa6/src/editors/multiple.js#L273). `A` has a better `fitTest` result than `B` because the test value has the `common` property which is included in the properties of `A` but not in the (direct) properties of `B`. The fact that `validator.validate()` failed (i.e. returned a non-empty array of errors) for `A` and the test value is ignored.

The proposed change solves this problem by changing the `fitTest` implementation so that the properties of nested `anyOf` types are also considered. In our example, this leads to a better result for `fitTest` when called with schema `B` compared to schema `A`.