### PR TITLE
Remove documentation suggesting datetime is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,6 @@ JSON Editor uses HTML5 input types, so some of these may render as basic text in
 
 *  color
 *  date
-*  datetime
 *  datetime-local
 *  email
 *  month

--- a/docs/meta_schema.json
+++ b/docs/meta_schema.json
@@ -75,7 +75,6 @@
           "enum":[
             "color",
             "date",
-            "datetime",
             "datetime-local",
             "email",
             "month",

--- a/tests/pages/meta_schema.json
+++ b/tests/pages/meta_schema.json
@@ -75,7 +75,6 @@
           "enum":[
             "color",
             "date",
-            "datetime",
             "datetime-local",
             "email",
             "month",


### PR DESCRIPTION
| Updated README/docs?   | ✔️

The welcome README documentation suggests that both `datetime` and `datetime-local` are supported formats:
![Screen Shot 2021-07-27 at 09 32 56](https://user-images.githubusercontent.com/1108513/127123002-8f6e8297-fde4-42f0-8705-682290a7c939.png)


But, the HTML standard for the format of an `input` object is `datetime-local`, since `datetime` has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime)

The `json-editor` [samples](https://json-editor.github.io/json-editor/datetime.html) only support `datetime-local`, and in usage`json-editor` appears to only support `datetime-local`.

The PR removes the confusion by removing `datetime` format from the README.