### PR TITLE
Add accessibility support for empty theads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - switched CI to Github Actions
 - read-only base64 editors respect enum values when calling setValue()
 - fix bug in validator.fitTest where anyOf schemata were not handled correctly
+- fixes accessibility support for thead that consist of an empty string
 
 ### 2.5.4
 

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -99,6 +99,7 @@ export class TableEditor extends ArrayEditor {
 
     /* Row Controls column */
     this.controls_header_cell = this.theme.getTableHeaderCell(' ')
+    this.controls_header_cell.setAttribute('aria-hidden', 'true')
     this.header_row.appendChild(this.controls_header_cell)
 
     /* Add controls */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  |
| Updated README/docs?   | ✔️
| Added CHANGELOG entry?   | ✔️

## What does this PR contain?

Added an `aria-hidden="true"` to empty th to pass[ this accessibility rule](https://dequeuniversity.com/rules/axe/4.2/empty-table-header?application=axeAPI). 