### PR TITLE
fix error: "The node to be removed is not a child of this node" when …

### DIFF
--- a/src/editors/upload.js
+++ b/src/editors/upload.js
@@ -257,7 +257,7 @@ export class UploadEditor extends AbstractEditor {
 
     if (this.options.auto_upload) {
       uploadButton.dispatchEvent(new window.MouseEvent('click'))
-      this.preview.removeChild(uploadButton)
+      uploadButton.parentNode.removeChild(uploadButton)
     }
   }
 


### PR DESCRIPTION
…auto_upload is set to true

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #1061
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
