### PR TITLE
add infoText for multiselect enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Add infoText for enums with format `checkbox` (default)
+
 ### 2.6.1
 
 - Fix for #900 to close the properties modal when we click outside modal

--- a/README.md
+++ b/README.md
@@ -1035,23 +1035,24 @@ Editor Options
 
 Editors can accept options which alter the behavior in some way.
 
-*  `collapsed` - If set to true, the editor will start collapsed (works for objects and arrays)
-*  `disable_array_add` - If set to true, the "add row" button will be hidden (works for arrays)
-*  `disable_array_delete` - If set to true, all of the "delete" buttons will be hidden (works for arrays)
-*  `disable_array_delete_all_rows` - If set to true, just the "delete all rows" button will be hidden (works for arrays)
-*  `disable_array_delete_last_row` - If set to true, just the "delete last row" buttons will be hidden (works for arrays)
-*  `disable_array_reorder` - If set to true, the "move up/down" buttons will be hidden (works for arrays)
-*  `disable_collapse` - If set to true, the collapse button will be hidden (works for objects and arrays)
-*  `disable_edit_json` - If set to true, the Edit JSON button will be hidden (works for objects)
-*  `disable_properties` - If set to true, the Edit Properties button will be hidden (works for objects)
-*  `array_controls_top` - If set to true, array controls (add, delete etc) will be displayed at top of list (works for arrays)
-*  `enum_titles` - An array of display values to use for select box options in the same order as defined with the `enum` keyword. Works with schema using enum values.
-*  `expand_height` - If set to true, the input will auto expand/contract to fit the content.  Works best with textareas.
-*  `grid_columns` - Explicitly set the number of grid columns (1-12) for the editor if it's within an object using a grid layout.
-*  `hidden` - If set to true, the editor will not appear in the UI (works for all types)
-*  `input_height` - Explicitly set the height of the input element. Should be a valid CSS width string (e.g. "100px").  Works best with textareas.
-*  `input_width` - Explicitly set the width of the input element. Should be a valid CSS width string (e.g. "100px").  Works for string, number, and integer data types.
-*  `remove_empty_properties` - If set to true for an object, empty object properties (i.e. those with falsy values) will not be returned by getValue().
+* `collapsed` - If set to true, the editor will start collapsed (works for objects and arrays)
+* `disable_array_add` - If set to true, the "add row" button will be hidden (works for arrays)
+* `disable_array_delete` - If set to true, all of the "delete" buttons will be hidden (works for arrays)
+* `disable_array_delete_all_rows` - If set to true, just the "delete all rows" button will be hidden (works for arrays)
+* `disable_array_delete_last_row` - If set to true, just the "delete last row" buttons will be hidden (works for arrays)
+* `disable_array_reorder` - If set to true, the "move up/down" buttons will be hidden (works for arrays)
+* `disable_collapse` - If set to true, the collapse button will be hidden (works for objects and arrays)
+* `disable_edit_json` - If set to true, the Edit JSON button will be hidden (works for objects)
+* `disable_properties` - If set to true, the Edit Properties button will be hidden (works for objects)
+* `array_controls_top` - If set to true, array controls (add, delete etc) will be displayed at top of list (works for arrays)
+* `enum` - See [Enum options](#enum-options)
+* `enum_titles` - An array of display values to use for select box options in the same order as defined with the `enum` keyword. Works with schema using enum values.
+* `expand_height` - If set to true, the input will auto expand/contract to fit the content.  Works best with textareas.
+* `grid_columns` - Explicitly set the number of grid columns (1-12) for the editor if it's within an object using a grid layout.
+* `hidden` - If set to true, the editor will not appear in the UI (works for all types)
+* `input_height` - Explicitly set the height of the input element. Should be a valid CSS width string (e.g. "100px").  Works best with textareas.
+* `input_width` - Explicitly set the width of the input element. Should be a valid CSS width string (e.g. "100px").  Works for string, number, and integer data types.
+* `remove_empty_properties` - If set to true for an object, empty object properties (i.e. those with falsy values) will not be returned by getValue().
 
 ```json
 {
@@ -1086,6 +1087,43 @@ Using the option `infoText`, will create a info button, displaying the text you 
 }
 ```
 
+Enum options
+------------------
+
+Using the option `enum`, it is possible to modify how enums with format `checkbox` (default) are displayed in the editor.
+It is an array of objects (described below), which must be in the same order as defined with the `enum` keyword.
+
+Currently, the following is supported:
+
+* `title`: *Optional* Display value shown instead of the enum value
+* `infoText`: *Optional* Creates an info button next to the title, displaying the text you set, on hovering.
+
+It is possible also to set these options only for some enum values, to skip one enum value, define an empty object (`{}`).
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "string",
+    "enum": ["1", "2", "3", "4"],
+    "options": {
+      "enum": [
+        {},
+        {
+          "title": "Title 2"
+        },
+        { "infoText": "InfoText 3" },
+        {
+          "title": "Title 4",
+          "infoText": "InfoText 4"
+        }
+      ]
+    }
+  }
+}
+```
+
+If both options `enum_titles[x]` and `enum[x].title` are set for the enum value `x`, than the title set under `enum[x].title` will be used.
 
 Dependencies
 ------------------

--- a/tests/codeceptjs/editors/array_test.js
+++ b/tests/codeceptjs/editors/array_test.js
@@ -478,6 +478,30 @@ Scenario('should work well with checkbox editors', async (I) => {
   I.dontSee('Checkbox 3');
 });
 
+Scenario('should work well with checkbox editors with infoText', async (I) => {
+  I.amOnPage('array-checkboxes-infotext.html')
+
+  function check (checkboxId, title, infoText) {
+    const label = '//label[@for="' + checkboxId + '"]'
+    I.see(title, label)
+    const infoTextIcon = label + '/span[@class="je-infobutton-icon"]'
+
+    if (infoText) {
+      I.seeElement(infoTextIcon)
+      I.moveCursorTo(infoTextIcon)
+      I.see(infoText, label + '//span[@class="je-infobutton-tooltip"]')
+    } else {
+      I.dontSeeElement(infoTextIcon)
+    }
+  }
+
+  check('root0', 'old a')
+  check('root1', 'b')
+  check('root2', '3')
+  check('root3', '4', 'dd')
+  check('root4', 'e', 'ee')
+})
+
 Scenario('should work well with rating editors', async (I) => {
   I.amOnPage('array-ratings.html');
   I.seeElement('[data-schemapath="root.0"]');

--- a/tests/pages/array-checkboxes-infotext.html
+++ b/tests/pages/array-checkboxes-infotext.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <script src="../../dist/jsoneditor.js"></script>
+</head>
+<body>
+
+<textarea class="debug" cols="30" rows="10"></textarea>
+<button class='get-value'>Get Value</button>
+<div class='container'></div>
+
+<script>
+  var container = document.querySelector('.container')
+  var debug = document.querySelector('.debug')
+  var schema = {
+    'title': 'Checkbox with Infotext',
+    'type': 'array',
+    'uniqueItems': true,
+    'items': {
+      'type': 'string',
+      'enum': ['1', '2', '3', '4', '5'],
+      'options': {
+        'enum_titles': ['old a', 'old b'],
+        'enum': [
+          {},
+          {
+            'title': 'b',
+          },
+          {},
+          { 'infoText': 'dd' },
+          {
+            'title': 'e',
+            'infoText': 'ee'
+          }
+        ]
+      }
+    }
+  }
+
+  var editor = new JSONEditor(container, {
+    schema: schema
+  })
+
+  document.querySelector('.get-value').addEventListener('click', function () {
+    debug.value = JSON.stringify(editor.getValue())
+  })
+
+</script>
+
+</body>
+</html>

--- a/tests/pages/meta_schema.json
+++ b/tests/pages/meta_schema.json
@@ -625,6 +625,20 @@
                 "tilte":"title"
               }
             },
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "infoText":{
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "grid_columns":{
               "type":"integer",
               "default": 1,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ✔️
| Added CHANGELOG entry?   | ✔️

This PR add the feature to specify also info text for enums in an array.
As this is my first contribution to a javascript project, please let me know if I missed something.

I introduce a new option key named `enum`, which holds an array of object.
On each object you can specify:
- `title`: The title of the enum (similar to `enum_titles`)
- `infoText`: The info text showing aside the checkbox

Both keys can are optional.
`enum_titles` was the old way to specify the titles and I left it in for backwards compatibility. 

The schema looks like 
```json
{
  "title": "Checkbox with Infotext",
  "type": "array",
  "uniqueItems": true,
  "items": {
    "type": "string",
    "enum": ["1", "2", "3", "4", "5"],
    "options": {
      "enum_titles": ["old a", "old b"],
      "enum": [
        {},
        {
          "title": "b"
        },
        {},
        { "infoText": "dd" },
        {
          "title": "e",
          "infoText": "ee"
        }
      ]
    }
  }
}
```
