### PR TITLE
Schema loader: Load schemas in parallel

### DIFF
--- a/tests/codeceptjs/core_test.js
+++ b/tests/codeceptjs/core_test.js
@@ -245,6 +245,7 @@ Scenario('should load internal schema definitions, external schema definitions a
 
 Scenario('should override error messages if specified in schema options @core @errors-messages', async (I) => {
   I.amOnPage('error-messages.html')
+  I.waitForElement('.je-ready')
   I.waitForText('Error Messages')
 
   I.waitForText('CUSTOM EN: Value required')


### PR DESCRIPTION
**Problem**
Loading a schema with many externally-referenced schemas can take a long time, because the schema API xhr calls are fetched serially, instead of in parallel. See `_asyncloadExternalRefs()` in `src/schemaloader.js`. 

I _think_ this behavior was introduced in [this commit](https://github.com/json-editor/json-editor/pull/1082/commits/58715ddd0f94ccb33eaf1b71b3f70c03f4739f86) from PR #1082. 

**The fix**
This new PR allows requests to run in parallel. The two main changes are:
1. Do not `await` each xhr request. Instead, when it's finished, add its results to the shared schemas list.
2. Make the top-level schemas loader wait until all schemas have been fetched. This is ugly code, because it uses a poller. There must be a better way to accomplish this using Promises or callbacks, but I couldn't find any other solutions.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | This PR only
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌


