### PR TITLE
select2/selectize cannnot add new option: jsoneditor.js:11484 Uncaugh…

### DIFF
--- a/src/editors/multiselect.js
+++ b/src/editors/multiselect.js
@@ -32,6 +32,7 @@ export class MultiSelectEditor extends AbstractEditor {
 
     this.select_options = {}
     this.select_values = {}
+    this.option_titles = []
     this.option_keys = []
     this.option_enum = []
 


### PR DESCRIPTION
…t TypeError: Cannot read properties of undefined (reading 'push')

    at ArraySelect2Editor.addNewOption (jsoneditor.js:11484:26)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
