### PR TITLE
fixed the format documentation to properly use SCEditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,12 +754,12 @@ Like this:
 
 In addition to the standard HTML input formats, JSON Editor can also integrate with several 3rd party specialized editors.  These libraries are not included in JSON Editor and you must load them on the page yourself.
 
-__SCEditor__ provides WYSIWYG editing of HTML and BBCode.  To use it, set the format to `html` or `bbcode` and set the `wysiwyg` option to `true`:
+__SCEditor__ provides WYSIWYG editing of HTML and BBCode.  To use it, set the format to `xhtml` or `bbcode` and set the `wysiwyg` option to `true`:
 
 ```json
 {
   "type": "string",
-  "format": "html",
+  "format": "xhtml",
   "options": {
     "wysiwyg": true
   }


### PR DESCRIPTION
This is an update to the readme file. It incorrectly says to use the format `html` if you want to use SCEditor. It should be `xhtml`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | 
| Updated README/docs?   | ✔️
| Added CHANGELOG entry?   | ❌
