### PR TITLE
Fix for #1257 (default color doesn't work inside array)

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -537,6 +537,8 @@ export class ObjectEditor extends AbstractEditor {
         editor.postBuild()
         editor.setOptInCheckbox(editor.header)
 
+        editor.setValue(editor.getDefault(), true)
+
         if (this.editors[key].options.hidden) {
           holder.style.display = 'none'
         }

--- a/tests/codeceptjs/editors/issues/issue-gh-1257_test.js
+++ b/tests/codeceptjs/editors/issues/issue-gh-1257_test.js
@@ -1,0 +1,13 @@
+/* global Feature Scenario */
+
+const assert = require('assert')
+
+Feature('GitHub issue 1257')
+
+Scenario('GitHub issue 1257 should remain fixed @issue-1257', async (I) => {
+  I.amOnPage('issues/issue-gh-1257.html')
+  I.waitForElement('.je-ready')
+  I.click('[data-schemapath="root.colors"] .json-editor-btntype-add')
+  assert.equal(await I.grabValueFrom('#value'), '{"colors":[{"text":"X","color":"#fefaac"}],"color":"#fefaac"}')
+  assert.equal(await I.grabValueFrom('[name="root[colors][0][color]"]'), '#fefaac')
+})

--- a/tests/pages/issues/issue-gh-1257.html
+++ b/tests/pages/issues/issue-gh-1257.html
@@ -5,7 +5,7 @@
   <title>GitHub Issue 1257</title>
   <link rel="stylesheet" id="theme-link" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
   <link rel="stylesheet" id="iconlib-link" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
-  <script src="../../../dist/nonmin/jsoneditor.js"></script>
+  <script src="../../../dist/jsoneditor.js"></script>
 </head>
 <body>
 

--- a/tests/pages/issues/issue-gh-1257.html
+++ b/tests/pages/issues/issue-gh-1257.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8"/>
+  <title>GitHub Issue 1257</title>
+  <link rel="stylesheet" id="theme-link" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
+  <link rel="stylesheet" id="iconlib-link" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
+  <script src="../../../dist/nonmin/jsoneditor.js"></script>
+</head>
+<body>
+
+<div class="container">
+  <h1><a href="https://github.com/json-editor/json-editor/issues/1257">GitHub Issue 1257</a></h1>
+  <label for="value">Value</label>
+  <textarea class="form-control" id="value" rows="12" style="font-size: 12px; font-family: monospace;"></textarea>
+  <button id="set-value">Set Value</button>
+  <div class='json-editor-container'></div>
+</div>
+
+<script>
+  var jsonEditorContainer = document.querySelector('.json-editor-container')
+  var value = document.querySelector('#value')
+  var setValue = document.querySelector('#set-value')
+  var schema = {
+    "title": "default color array demo",
+    "type": "object",
+    "properties": {
+      "colors": {
+        "type": "array",
+        "format": "table",
+        "title": "colors",
+        "uniqueItems": true,
+        "items": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "default": "X"
+            },
+            "color": {
+              "type": "string",
+              "format": "color",
+              "default": "#fefaac"
+            }
+          }
+        }
+      },
+      "color": {
+        "type": "string",
+        "format": "color",
+        "default": "#fefaac"
+      }
+    }
+  }
+
+  var editor = new JSONEditor(jsonEditorContainer, {
+    schema: schema,
+    theme: 'bootstrap4',
+    show_errors: 'always',
+    iconlib: 'fontawesome5',
+    disable_collapse: true,
+    disable_edit_json: true,
+    disable_properties: true,
+    keep_oneof_values: false
+  })
+
+  editor.on('change', function () {
+    value.value = JSON.stringify(editor.getValue())
+  })
+
+  setValue.addEventListener('click', function () {
+    editor.setValue(JSON.parse(value.value))
+  })
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
The input type color loses the "html" value when the relative editor is moved to another container element. In this case, a <td> element. This does not happen with other complex inputs like "date", "date-time" or "month" inputs. Setting default value after being moved / appended to <td> fixes the issue and does not triggers any extra change event.

|when being  Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #[1257](https://github.com/json-editor/json-editor/issues/1257)
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
