### PR TITLE
Fix for #1164: Null values included in enums for no reason

### DIFF
--- a/src/editors/radio.js
+++ b/src/editors/radio.js
@@ -21,12 +21,6 @@ export class RadioEditor extends SelectEditor {
       this.onChange(true)
     }
 
-    if (!this.isRequired()) {
-      this.enum_display.shift()
-      this.enum_options.shift()
-      this.enum_values.shift()
-    }
-
     for (let i = 0; i < this.enum_values.length; i++) {
       /* form radio elements */
       const attributes = {
@@ -109,6 +103,10 @@ export class RadioEditor extends SelectEditor {
   }
 
   setValue (val) {
+    if (typeof val !== 'string') {
+      val = String(val)
+    }
+
     for (let i = 0; i < this.radioGroup.length; i++) {
       if (this.radioGroup[i].value === val) {
         this.radioGroup[i].checked = true

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -82,12 +82,6 @@ export class SelectEditor extends AbstractEditor {
         this.enum_display[i] = `${this.translateProperty(display[i]) || option}`
         this.enum_values[i] = this.typecast(option)
       })
-
-      if (!this.isRequired()) {
-        this.enum_display.unshift(' ')
-        this.enum_options.unshift('undefined')
-        this.enum_values.unshift(undefined)
-      }
       /* Boolean */
     } else if (this.schema.type === 'boolean') {
       this.enum_display = (this.schema.options && this.schema.options.enum_titles) || ['true', 'false']

--- a/tests/codeceptjs/editors/issues/issue-gh-1164_test.js
+++ b/tests/codeceptjs/editors/issues/issue-gh-1164_test.js
@@ -1,0 +1,12 @@
+/* global Feature Scenario */
+
+const assert = require('assert')
+
+Feature('GitHub issue 1164')
+
+Scenario('GitHub issue 1164 should remain fixed @issue-1164', async (I) => {
+  I.amOnPage('issues/issue-gh-1164.html')
+  I.waitForElement('.je-ready')
+  I.waitForInvisible('option[value="undefined"]')
+  assert.equal(await I.grabValueFrom('#value'), '{"arrayEnumSelect":["one"],"stringEnumRadio":"one","numberEnumRadio":1.1,"integerEnumRadio":1}')
+})

--- a/tests/pages/issues/issue-gh-1164.html
+++ b/tests/pages/issues/issue-gh-1164.html
@@ -5,8 +5,7 @@
     <title>GitHub Issue 1164</title>
     <link rel="stylesheet" id="theme-link" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
     <link rel="stylesheet" id="iconlib-link" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
-<!--      <script src="../../../dist/jsoneditor.js"></script>-->
-    <script src="../../../dist/nonmin/jsoneditor.js"></script>
+      <script src="../../../dist/jsoneditor.js"></script>
 </head>
 <body>
 

--- a/tests/pages/issues/issue-gh-1164.html
+++ b/tests/pages/issues/issue-gh-1164.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8"/>
+    <title>GitHub Issue 1164</title>
+    <link rel="stylesheet" id="theme-link" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
+    <link rel="stylesheet" id="iconlib-link" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
+<!--      <script src="../../../dist/jsoneditor.js"></script>-->
+    <script src="../../../dist/nonmin/jsoneditor.js"></script>
+</head>
+<body>
+
+<div class="container">
+    <h1><a href="https://github.com/json-editor/json-editor/issues/1164">GitHub Issue 1164</a></h1>
+    <label for="value">Value</label>
+    <textarea class="form-control" id="value" rows="6" style="font-size: 12px; font-family: monospace;"></textarea>
+    <div class='json-editor-container'></div>
+</div>
+
+<script>
+  var jsonEditorContainer = document.querySelector('.json-editor-container')
+  var value = document.querySelector('#value')
+  var schema = {
+    'type': 'object',
+    'properties': {
+      'arrayEnumSelect': {
+        'title': 'Array enum select',
+        'type': 'array',
+        'minItems': 1,
+        'items': {
+          'type': 'string',
+          'enum': ['one', 'two', 'three']
+        }
+      },
+      'stringEnumRadio': {
+        'title': 'String enum radio',
+        'type': 'string',
+        'format': 'radio',
+        'enum': ['one', 'two', 'three']
+      },
+      'numberEnumRadio': {
+        'title': 'Number enum radio',
+        'type': 'number',
+        'format': 'radio',
+        'enum': [1.1, 2.2, 3.3]
+      },
+      'integerEnumRadio': {
+        'title': 'Integer enum radio',
+        'type': 'integer',
+        'format': 'radio',
+        'enum': [1, 2, 3]
+      }
+    }
+  }
+
+  var editor = new JSONEditor(jsonEditorContainer, {
+    schema: schema,
+    theme: 'bootstrap4',
+    show_errors: 'always',
+    iconlib: 'fontawesome5',
+    disable_collapse: true,
+    disable_edit_json: true,
+    disable_properties: true
+  })
+
+  editor.on('change', function () {
+    value.value = JSON.stringify(editor.getValue())
+  })
+</script>
+
+</body>
+</html>

--- a/tests/unit/core.spec.js
+++ b/tests/unit/core.spec.js
@@ -217,7 +217,7 @@ describe('JSONEditor', function () {
         editor.promise.then(() => {
           expect(editor.getValue()).toEqual({
             boolean: undefined,
-            enum: undefined,
+            enum: 'foo',
             integer: undefined,
             number: undefined,
             string: undefined,
@@ -235,7 +235,7 @@ describe('JSONEditor', function () {
         editor.promise.then(() => {
           expect(editor.getValue()).toEqual({
             boolean: undefined,
-            enum: undefined,
+            enum: 'foo',
             integer: undefined,
             number: undefined,
             string: undefined,
@@ -249,7 +249,7 @@ describe('JSONEditor', function () {
 
           expect(editor.getValue()).toEqual({
             boolean: undefined,
-            enum: undefined,
+            enum: 'foo',
             integer: 3,
             number: 4,
             string: 'foo',
@@ -263,7 +263,7 @@ describe('JSONEditor', function () {
 
           expect(editor.getValue()).toEqual({
             boolean: undefined,
-            enum: undefined,
+            enum: 'foo',
             integer: undefined,
             number: undefined,
             string: '',
@@ -290,7 +290,8 @@ describe('JSONEditor', function () {
         editor.promise.then(() => {
           expect(editor.getValue()).toEqual({
             string_with_default: 'foobar',
-            enum_with_default: 'foobar'
+            enum_with_default: 'foobar',
+            enum_without_default: 'foobar'
           })
         })
       })


### PR DESCRIPTION
Fix for #1164: Null values included in enums for no reason.
Also fixes radio editors not recognising numerical values.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #1164
