### PR TITLE
tests: using waitForValue in some tests

### DIFF
--- a/tests/codeceptjs/core_test.js
+++ b/tests/codeceptjs/core_test.js
@@ -216,35 +216,35 @@ Scenario('Should switch between all json 7 data types in @oneof and display erro
   assert.equal(await I.grabValueFrom('#value'), '{"test":null}')
 })
 
-Scenario('Should switch between all json 7 data types in @anyof and display error messages for each one @core', async ({ I }) => {
+Scenario('Should switch between all json 7 data types in @anyof and display error messages for each one @core', ({ I }) => {
   I.amOnPage('anyof-2.html')
   I.waitForElement('.je-ready')
 
-  assert.equal(await I.grabValueFrom('#value'), '{"test":""}')
+  I.waitForValue('#value', '{"test":""}')
   I.waitForText('Value must validate against at least one of the provided schemas')
 
   I.selectOption('.je-switcher', 'Value, boolean')
-  assert.equal(await I.grabValueFrom('#value'), '{"test":false}')
+  I.waitForValue('#value', '{"test":false}')
   I.waitForText('Value must validate against at least one of the provided schemas')
 
   I.selectOption('.je-switcher', 'Value, array')
-  assert.equal(await I.grabValueFrom('#value'), '{"test":[]}')
+  I.waitForValue('#value', '{"test":[]}')
   I.waitForText('Value must validate against at least one of the provided schemas')
 
   I.selectOption('.je-switcher', 'Value, object')
-  assert.equal(await I.grabValueFrom('#value'), '{"test":{}}')
+  I.waitForValue('#value', '{"test":{}}')
   I.waitForText('Value must validate against at least one of the provided schemas')
 
   I.selectOption('.je-switcher', 'Value, number')
-  assert.equal(await I.grabValueFrom('#value'), '{"test":0}')
+  I.waitForValue('#value', '{"test":0}')
   I.waitForText('Value must validate against at least one of the provided schemas')
 
   I.selectOption('.je-switcher', 'Value, integer')
-  assert.equal(await I.grabValueFrom('#value'), '{"test":0}')
+  I.waitForValue('#value', '{"test":0}')
   I.waitForText('Value must validate against at least one of the provided schemas')
 
   I.selectOption('.je-switcher', 'Value, null')
-  assert.equal(await I.grabValueFrom('#value'), '{"test":null}')
+  I.waitForValue('#value', '{"test":null}')
 })
 
 Scenario('should validate against oneOf schemas and display single oneOf and editors error messages @core @translate-property', async ({ I }) => {

--- a/tests/codeceptjs/editors/issues/issue-gh-1164_test.js
+++ b/tests/codeceptjs/editors/issues/issue-gh-1164_test.js
@@ -1,12 +1,10 @@
 /* global Feature Scenario */
 
-const assert = require('assert')
-
 Feature('GitHub issue 1164')
 
-Scenario('GitHub issue 1164 should remain fixed @issue-1164', async ({ I }) => {
+Scenario('GitHub issue 1164 should remain fixed @issue-1164', ({ I }) => {
   I.amOnPage('issues/issue-gh-1164.html')
   I.waitForElement('.je-ready')
   I.waitForInvisible('option[value="undefined"]')
-  assert.equal(await I.grabValueFrom('#value'), '{"arrayEnumSelect":["one"],"stringEnumRadio":"one","numberEnumRadio":1.1,"integerEnumRadio":1}')
+  I.waitForValue('#value', '{"arrayEnumSelect":["one"],"stringEnumRadio":"one","numberEnumRadio":1.1,"integerEnumRadio":1}')
 })


### PR DESCRIPTION
Opportunity to remove not needed `async` functions and calls to old node `assert` functions

| Tests pass?   | ✔️
