### PR TITLE
Removed inline inline styling that breaks property checkboxes in boot…

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -893,7 +893,6 @@ export class ObjectEditor extends AbstractEditor {
     let labelText
 
     const checkbox = this.theme.getCheckbox()
-    checkbox.style.width = 'auto'
 
     if (this.schema.properties[key] && this.schema.properties[key].title) { labelText = this.schema.properties[key].title } else { labelText = key }
 


### PR DESCRIPTION
…strap 5.

| Is bugfix?    | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #1317
