### PR TITLE
Fix issue in interactive demo:  Load jquery before loading selectize

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -407,6 +407,7 @@
       },
       selectize: {
         js: [
+          'https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js',
           'https://cdn.jsdelivr.net/npm/selectize@0.12.6/dist/js/standalone/selectize.min.js'
         ],
         css: [


### PR DESCRIPTION
The [interactive demo](https://json-editor.github.io/json-editor/) fails to load `jquery` prior to loading `selectize`, causing the following console error:

```
selectize.min.js:3 Uncaught TypeError: Cannot read properties of undefined (reading 'fn')
    at selectize.min.js:3:6679
    at selectize.min.js:3:5992
    at selectize.min.js:3:6027
```

You can workaround this issue inside the demo by selecting `select2` from the menu *before* multi-selecting `selectize`.

As recommended [here](https://stackoverflow.com/a/20607939), this PR fixes this issue by loading `jquery` prior to loading `selectize` (like as is currently done for select2 within the demo).

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | N/A
| Fixed issues  | N/A
| Updated README/docs?   | ✔️
| Added CHANGELOG entry?   | ❌
