### PR TITLE
Fix issue #1453 buttons in array editor are not correctly setup when array editor is initially collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Fixed issue #1453 setup buttons in array editor correctly if editor is initially collapsed
+
 ### 2.13.1
 
 - Fixed bug in enumTitle for headerTemplates

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -454,7 +454,7 @@ export class ArrayEditor extends AbstractEditor {
         this.value[i] = editor.getValue()
       })
 
-      if (!this.collapsed && this.setupButtons(minItems)) {
+      if (this.setupButtons(minItems) && !this.collapsed) {
         this.controls.style.display = 'inline-block'
       } else {
         this.controls.style.display = 'none'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #1453 
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️
