### PR TITLE
Fix Object.keys on undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 - Fixed issue #1453 setup buttons in array editor correctly if editor is initially collapsed
+- Fixed bug in onWatchedFileChange
 
 ### 2.13.1
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -521,7 +521,7 @@ export class AbstractEditor {
       })
 
       // object properties
-      if (Object.keys(this.editors).length) {
+      if (Object.keys(this.editors || {}).length) {
         vars.properties = {}
 
         Object.keys(this.editors).forEach((key) => {


### PR DESCRIPTION
this.editors is not defined for some editor classes. Add a default value to avoid errors.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | 
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️
