### PR TITLE
Fixed issue #1487, edited object.js

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -927,6 +927,7 @@ export class ObjectEditor extends AbstractEditor {
 
     checkbox.checked = key in this.editors
     checkbox.addEventListener('change', () => {
+      this.hideAddProperty()
       if (checkbox.checked) {
         this.addObjectProperty(key)
       } else {


### PR DESCRIPTION
Changed the default behavior of showing a table tab to hide, rather than spilling below and showing both.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #1487 
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
