### PR TITLE
Bootstrap 5 — Add support for non-jQuery tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Removed jQuery requirement for Bootstrap 5 theme.
+
 ### 2.15.1
 
 - Fixed #1563 and #1558. Select values not displayed

--- a/src/themes/bootstrap5.js
+++ b/src/themes/bootstrap5.js
@@ -241,14 +241,31 @@ export class bootstrap5Theme extends AbstractTheme {
     button.appendChild(icon)
 
     if (this.options.tooltip === 'bootstrap') {
+      const consoleCodeBlockStyle =
+        'background: #EEE; padding: 0.1rem 0.3rem; word-wrap: break-word; box-decoration-break: clone;'
+
       if (window.bootstrap && window.bootstrap.Tooltip) {
         // eslint-disable-next-line no-new
         new window.bootstrap.Tooltip(button)
       } else if (window.jQuery && window.jQuery().tooltip) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Could not find property %cwindow.bootstrap%c; falling back to jQuery tooltips.\n' +
+            'Keep in mind that Bootstrap 5 is designed to be used without jQuery.',
+          consoleCodeBlockStyle,
+          ''
+        )
         window.jQuery(button).tooltip()
       } else {
         // eslint-disable-next-line no-console
-        console.warn('Could not find popper jQuery plugin of Bootstrap.')
+        console.warn(
+          'Could not find property %cwindow.bootstrap%c; please ensure that Bootstrap is loaded in your app ' +
+            '(%cif using a package manager, you may need to manually assign the bootstrap variable: %cwindow.bootstrap = require("bootstrap")',
+          consoleCodeBlockStyle,
+          '',
+          'font-style: italic',
+          consoleCodeBlockStyle
+        )
       }
     } else if (this.options.tooltip === 'css') {
       button.classList.add('je-tooltip')

--- a/src/themes/bootstrap5.js
+++ b/src/themes/bootstrap5.js
@@ -241,7 +241,10 @@ export class bootstrap5Theme extends AbstractTheme {
     button.appendChild(icon)
 
     if (this.options.tooltip === 'bootstrap') {
-      if (window.jQuery && window.jQuery().tooltip) {
+      if (window.bootstrap && window.bootstrap.Tooltip) {
+        // eslint-disable-next-line no-new
+        new window.bootstrap.Tooltip(button)
+      } else if (window.jQuery && window.jQuery().tooltip) {
         window.jQuery(button).tooltip()
       } else {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #1108
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️


Quoting from the Bootstrap 5 documentation (emphasis original):
> **You don’t need jQuery in Bootstrap 5**, but it’s still possible to use our components with jQuery

The jQuery dependency for tooltips has been removed in Bootstrap 5; however, the theme file for Bootstrap 5 doesn't account for this.

This change introduces support for the jQuery-free Bootstrap tooltips, while maintain support for the jQuery tooltips (albeit as a secondary options, not a default). I wasn't sure if this would be considered a "feature" or "bugfix", so I marked it as both. (On one hand, it introduces new capabilities; on the other hand, the fact that the "bootstrap" tooltips relied entirely on jQuery — and didn't even use Bootstrap — could be argued to be a bug).


![image](https://github.com/json-editor/json-editor/assets/82973850/b0026dfc-2acf-4971-a999-f711e7f71153)
![image](https://github.com/json-editor/json-editor/assets/82973850/e3fc635d-cb5e-420f-bf83-60b7875a8a6b)
