### PR TITLE
add `oneOf` bootstrap `pe-5` padding

### DIFF
--- a/src/themes/bootstrap5.js
+++ b/src/themes/bootstrap5.js
@@ -23,6 +23,7 @@ export class bootstrap5Theme extends AbstractTheme {
     const el = super.getSelectInput(options)
     el.classList.add('form-control')
     el.classList.add('form-select')
+    el.classList.add('pe-5')
     if (this.options.input_size === 'small') el.classList.add('form-control-sm')
     if (this.options.input_size === 'large') el.classList.add('form-control-lg')
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #1571 |
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

This PR adds padding to the Bootstrap selection class at the end, attempting to fix #1571.
Ideally, one might want to make the drop down full size, but adding `w-auto` or `lex-grow-1` did not fix the issue.

Suggestions for improvement are very welcome.

### Before
<img width="539" alt="image" src="https://github.com/user-attachments/assets/2f601625-0618-4cc7-a4eb-b585cc8ea151">

### After
<img width="539" alt="image" src="https://github.com/user-attachments/assets/77d1ba27-1360-4f15-928a-560d45343353">

