### PR TITLE
Update tailwind.js, fix issue with "required" class attribute for every input text field

### DIFF
--- a/src/themes/tailwind.js
+++ b/src/themes/tailwind.js
@@ -188,7 +188,7 @@ export class tailwindTheme extends AbstractTheme {
   getFormInputLabel (text, req) {
     const el = super.getFormInputLabel(text, req)
     if (this.options.label_bold) el.classList.add('font-bold')
-    else el.classList.add('required')
+    if (req) el.classList.add('required')
     return el
   }
 


### PR DESCRIPTION
The "required" class attribute will be displayed regardless of whether the field is actually required or not.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️❌
| New feature?  | ✔️❌
| Is backward-compatible?    | ✔️❌
| Tests pass?   | ✔️❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ✔️❌
| Added CHANGELOG entry?   | ✔️❌
