### PR TITLE
GH 1664: Adding infoText button to table headers

### DIFF
--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -91,6 +91,10 @@ export class TableEditor extends ArrayEditor {
       for (let i = 0; i < order.length; i++) {
         const th = this.theme.getTableHeaderCell(ce[order[i]].getTitle())
         if (ce[order[i]].options.hidden) th.style.display = 'none'
+        if (ce[order[i]].options.infoText) {
+          const infoButton = this.theme.getInfoButton(this.translateProperty(ce[order[i]].options.infoText))
+          th.appendChild(infoButton)
+        }
         this.header_row.appendChild(th)
       }
     } else {

--- a/tests/codeceptjs/issues/issue-gh-1664_test.js
+++ b/tests/codeceptjs/issues/issue-gh-1664_test.js
@@ -1,0 +1,10 @@
+/* global Feature Scenario */
+
+Feature('issues')
+
+Scenario('GitHub issue 1664 should remain fixed @issue-1664', async ({ I }) => {
+  I.amOnPage('issues/issue-gh-1664.html')
+  I.waitForElement('.je-ready')
+  I.see('A very long title', '[data-schemapath="root"] thead tr th:nth-child(1)')
+  I.seeElement('[data-schemapath="root"] thead tr th:nth-child(1) > button[title="A helptext"]')
+})

--- a/tests/pages/issues/issue-gh-1664.html
+++ b/tests/pages/issues/issue-gh-1664.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>dependentSchemas</title>
+  <script src="../../../dist/jsoneditor.js"></script>
+  <link rel="stylesheet" id="theme-link" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
+  <link rel="stylesheet" id="iconlib-link" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
+</head>
+<body>
+
+<div class="container">
+  <h1>Test</h1>
+  <div id='editor-container'></div>
+</div>
+
+<style>
+  th {
+    white-space: nowrap;
+  }
+</style>
+
+<script>
+  var editorContainer = document.querySelector('#editor-container')
+  var schema = {
+    "title": "Array table responsive",
+    "format": "table",
+    "type": "array",
+    "minItems": 1,
+    "items": {
+      "title": "item",
+      "type": "object",
+      "properties": {
+        "property_a": {
+          "title": "A very long title",
+          "options": {
+            "infoText": "A helptext"
+          },
+          "type": "string"
+        },
+        "property_b": {
+          "title": "Another long title",
+          "type": "string"
+        },
+        "property_c": {
+          "title": "Another long title too",
+          "type": "string"
+        },
+        "property_d": {
+          "title": "Another long title too",
+          "type": "string"
+        },
+        "property_e": {
+          "title": "Another long title too",
+          "type": "string"
+        }
+      }
+    }
+  }
+
+  var editor = new JSONEditor(editorContainer, {
+    schema: schema,
+    theme: 'bootstrap4',
+    iconlib: 'fontawesome',
+  })
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Currently, if I use the table format, any column-level infoText does not get displayed.  This PR aims to rectify that

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | 1664
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌
