### PR TITLE
Handle url encoded $ref pointers in subschema expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+- Fixed $refs with percent-encoded paths
 
 ### 2.15.2
 

--- a/src/schemaloader.js
+++ b/src/schemaloader.js
@@ -191,14 +191,14 @@ export class SchemaLoader {
   * Returns a subschema based on a JSON Pointer path.
   * @param {object} schema - Schema too into
   * @param {string} pointer - path to look for
-  * @param {object} original_schema - the Original schema
   * @returns the subschema pointed to by the path
   */
   expandRecursivePointer (schema, pointer) {
     let subschema = schema
-    pointer.split('/').slice(1).forEach(i => {
-      if (subschema[i]) {
-        subschema = subschema[i]
+    pointer.split('/').slice(1).forEach(p => {
+      const decodedPointer = decodeURIComponent(p)
+      if (subschema[decodedPointer]) {
+        subschema = subschema[decodedPointer]
       }
     })
     // If the result is a pointer, let's go for another turn

--- a/tests/codeceptjs/editors/validation_test.js
+++ b/tests/codeceptjs/editors/validation_test.js
@@ -8,7 +8,7 @@ Feature('Validations')
 
 Scenario('test validations in validation.html', ({ I }) => {
   I.amOnPage('validation.html')
-  const numberOfTestItemsExpected = 158
+  const numberOfTestItemsExpected = 160
   I.waitForElement('#output div:nth-child(' + numberOfTestItemsExpected + ')', DEFAULT_WAIT_TIME)
   I.seeNumberOfElements('#output div', numberOfTestItemsExpected)
   I.see('success')

--- a/tests/fixtures/validation.json
+++ b/tests/fixtures/validation.json
@@ -866,6 +866,31 @@
             }
         ]
     },
+    "definitions_encoded": {
+        "schema": {
+            "type": "object",
+            "properties": {
+                "encoded": {
+                    "$ref": "#/definitions/encoded%3Cstring%3E"
+                }
+            },
+            "definitions": {
+                "encoded<string>": {
+                    "$ref": "../fixtures/string.json"
+                }
+            }
+        },
+        "valid": [
+            {
+                "encoded": "test"
+            }
+        ],
+        "invalid": [
+            {
+                "encoded": 42
+            }
+        ]
+    },
     "$ref": {
         "schema": {
             "type": "object",


### PR DESCRIPTION
Fixes a bug where $refs with percent-encoding were not resolved and resulted in no validation (always passing) and no editor restrictions (can select anything).

Seems like it was already fixed a while ago in the original repo (https://github.com/jdorn/json-editor/issues/402).
As far as I could trace it back, last it worked was in 2.6.1 and broke in 2.7.0 with 615de2da likely being the cause where the path segments were not uri decoded.

In our specific case, we built a schema using ts-json-schema-generator with generics:
```ts
export type Foo = {
    foo: Bar<string>
}

export type Bar<T> = {
    bar: T
}
```

which then generated the following schema:
```json
{
  "$ref": "#/definitions/Foo",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "Bar<string>": {
      "additionalProperties": false,
      "properties": {
        "bar": {
          "type": "string"
        }
      },
      "required": [
        "bar"
      ],
      "type": "object"
    },
    "Foo": {
      "additionalProperties": false,
      "properties": {
        "foo": {
          "$ref": "#/definitions/Bar%3Cstring%3E"
        }
      },
      "required": [
        "foo"
      ],
      "type": "object"
    }
  }
}
```
and resulted in observing this bug.

As far as I can tell, this should be backward-compatible and I also added a minimal test case using <> in a defintion name.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | -
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️
