### PR TITLE
fix: Issue #1481 - generate new uuids when copying item of an array

### DIFF
--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -588,17 +588,18 @@ export class ArrayEditor extends AbstractEditor {
 
       value.forEach((row, j) => {
         if (j === i) {
+          let duplicatedRow = (typeof row === 'object' && row !== null) ? { ...row } : row
           /* Force generation of new UUID if the item has been cloned. */
           if (schema.items.type === 'string' && schema.items.format === 'uuid') {
-            row = generateUUID()
+            duplicatedRow = generateUUID()
           } else if (schema.items.type === 'object' && schema.items.properties) {
-            for (const key of Object.keys(row)) {
+            for (const key of Object.keys(duplicatedRow)) {
               if (schema.items.properties && schema.items.properties[key] && schema.items.properties[key].format === 'uuid') {
-                row[key] = generateUUID()
+                duplicatedRow[key] = generateUUID()
               }
             }
           }
-          value.push(row)
+          value.push(duplicatedRow)
         }
       })
 


### PR DESCRIPTION
When copying an item of an array with an uuid, the new item has the same uuid. Even though, each array element should have an unique uuid.

#### Manual Test Case

Bug can be observed [here](https://json-editor.github.io/json-editor/?data=N4Ig9gDgLglmB2BnEAuUBXRBTA+vAhgLa75RQBOMARulFsigGb4A22ANCBOWIdDlSyMw5XABMsLLHVTM2WTpnFD86FlBwA3VunqzWHEIXwAPHBOgALVAAZONMghyIopXITATUARk4BjfGxnLCQYWE1cbkgscigAT2D8cj9rJgMFEERLMAB3HBiecgYQGHg6cnw/WAQQTii+DQhAuhxjMyl4AHMoSxxRSsssMX15TlEPCJw5IKiIGNg9NNGQEOFk3D8EFxHDSA1SnByYMU7pVBAUrD8AayowE1qSzfgWanPhMvwc+l4sAFZHmAqAArK4aFj4OJgWjneAiYwsR6IS7GVCgeJzc5A0FVR6zeYwRYYdDHADyILBAEFyBU4miQBisOckrTHrAoFJmTTIQACMCMPkUqqIHlHHo89AksQ8/GxOljLAARxJomGKAouk4YSwhAY6LCnJQIElx0FOKgPJZvO1hDZcUxRuxYLxPDmsUJeuNUvpjPOLkoXUea2MUHOJuGAF8o9HOD0dUyjXcwFB/fgIAAWR6iZUwVUCBISZhqUNLQxiGCICAQhLZlVDHAIFh00sZLK5Bv8Uo7DJwnD4MTl6oEFg4WULBjTDL4YGmbuccuIfBUKT5Qc4YGIGot+cVpcrzYsCEQbBzkALveRV0ExaTneL5ckbkJftq29n3cPvtPvpYEQScinuen5WgWkjSAmb4hBeX60jgmwQM2GpTt+zwUGAbA4FAkCAR+K4geYYEtKwI48DkE7pHe0H4RIUgtBCLh9Lk3ZRkAA==)

When copying an item, we can see that both items have the same generated uuid.

#### Why does the bug happen ?

While copying, the item is not copied before modification.

#### Template

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | [Issue #1481](https://github.com/json-editor/json-editor/issues/1481) 
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌


