### PR TITLE
Improve rendering and schema loading performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ### Unreleased
 
 - Fixed #1559 and #1621 field dependent on false should now display
+- Improved rendering performance by building the editor tree off-screen and re-attaching in a single DOM operation
+- Improved schema loading performance by parallelizing external ref fetching and memoizing schema expansion
+- Narrowed validation error dispatch in ObjectEditor and ArrayEditor to avoid full-list scans per child editor
+- Lazy-initialize Validator instances in MultipleEditor; added getDefault() support for oneOf/anyOf per-type defaults
+- Added onContainerAttached() lifecycle hook to AbstractEditor; used by ObjectEditor (grid layout) and SignatureEditor (canvas sizing) to handle post-attachment initialization
 
 ### 2.15.2
 

--- a/src/core.js
+++ b/src/core.js
@@ -18,7 +18,9 @@ export class JSONEditor {
     this.element = element
     this.options = extend({}, JSONEditor.defaults.options, options)
     this.ready = false
+    this.building = false
     this.copyClipboard = null
+    this._editorClassCache = new Map()
     this.schema = this.options.schema
     this.template = this.options.template
     this.translate = this.options.translate || JSONEditor.defaults.translate
@@ -87,12 +89,30 @@ export class JSONEditor {
       container: this.root_container
     })
 
-    this.root.preBuild()
-    this.root.build()
-    this.root.postBuild()
+    /* Build off-screen: detach root_container to avoid per-element reflows */
+    this.element.removeChild(this.root_container)
+    this.building = true
 
-    /* Starting data */
-    if (hasOwnProperty(this.options, 'startval')) this.root.setValue(this.options.startval)
+    try {
+      this.root.preBuild()
+      this.root.build()
+      this.root.postBuild()
+
+      /* Starting data */
+      if (hasOwnProperty(this.options, 'startval')) this.root.setValue(this.options.startval)
+    } finally {
+      this.building = false
+      /* Re-attach the fully built DOM tree in one operation */
+      this.element.appendChild(this.root_container)
+    }
+
+    /* Notify all editors that the container is now in the DOM so they can perform
+     * layout-dependent initialization (e.g. measuring canvas dimensions). */
+    if (this.editors) {
+      Object.values(this.editors).forEach(editor => {
+        if (editor) editor.onContainerAttached()
+      })
+    }
 
     this.validation_results = this.validator.validate(this.root.getValue())
     this.root.showValidationErrors(this.validation_results)
@@ -215,6 +235,10 @@ export class JSONEditor {
   }
 
   getEditorClass (schema) {
+    const inputSchema = schema
+    const cached = this._editorClassCache.get(inputSchema)
+    if (cached) return cached
+
     let classname
 
     schema = this.expandSchema(schema)
@@ -225,17 +249,21 @@ export class JSONEditor {
     })
     if (!classname) throw new Error(`Unknown editor for schema ${JSON.stringify(schema)}`)
     if (!JSONEditor.defaults.editors[classname]) throw new Error(`Unknown editor ${classname}`)
-    return JSONEditor.defaults.editors[classname]
+
+    const editorClassResult = JSONEditor.defaults.editors[classname]
+    this._editorClassCache.set(inputSchema, editorClassResult)
+    return editorClassResult
   }
 
   createEditor (editorClass, options, depthCounter = 1) {
-    options = extend({}, editorClass.options || {}, options)
+    options = Object.assign({}, editorClass.options || {}, options)
     // eslint-disable-next-line new-cap
     return new editorClass(options, JSONEditor.defaults, depthCounter)
   }
 
   onChange (eventData) {
     if (!this.ready) return
+    if (this.building) return
 
     if (eventData) {
       this.trigger(eventData.event, eventData.data)

--- a/src/editor.js
+++ b/src/editor.js
@@ -16,7 +16,7 @@ export class AbstractEditor {
     this.schema = this.jsoneditor.expandSchema(this.original_schema)
     this.active = true
     this.isUiOnly = false
-    this.options = extend({}, (this.options || {}), (this.schema.options || {}), (options.schema.options || {}), options)
+    this.options = Object.assign({}, (this.options || {}), (this.schema.options || {}), (options.schema.options || {}), options)
     this.enforceConstEnabled = this.options.enforce_const ?? this.jsoneditor.options.enforce_const
     this.formname = this.jsoneditor.options.form_name_root || 'root'
 
@@ -54,6 +54,8 @@ export class AbstractEditor {
     if (!fromTemplate) {
       if (this.watch_listener) this.watch_listener()
     }
+
+    if (this.jsoneditor && this.jsoneditor.building) return
 
     if (bubble) this.change(eventData)
   }
@@ -257,6 +259,10 @@ export class AbstractEditor {
   }
 
   build () {
+
+  }
+
+  onContainerAttached () {
 
   }
 

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -833,12 +833,15 @@ export class ArrayEditor extends AbstractEditor {
   showValidationErrors (errors) {
     /* Get all the errors that pertain to this editor */
     const myErrors = []
-    const otherErrors = []
+    const childErrors = {}
+    const pathPrefix = this.path + '.'
     errors.forEach(error => {
       if (error.path === this.path) {
         myErrors.push(error)
-      } else {
-        otherErrors.push(error)
+      } else if (error.path.startsWith(pathPrefix)) {
+        const childIdx = error.path.substring(pathPrefix.length).split('.')[0]
+        if (!childErrors[childIdx]) childErrors[childIdx] = []
+        childErrors[childIdx].push(error)
       }
     })
 
@@ -856,9 +859,9 @@ export class ArrayEditor extends AbstractEditor {
       }
     }
 
-    /* Show errors for child editors */
-    this.rows.forEach(row =>
-      row.showValidationErrors(otherErrors)
+    /* Show errors for child editors -- only pass relevant errors */
+    this.rows.forEach((row, i) =>
+      row.showValidationErrors(childErrors[i] || [])
     )
   }
 }

--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -94,6 +94,28 @@ export class MultipleEditor extends AbstractEditor {
     this.refreshHeaderText()
   }
 
+  _getTypeSchema (i) {
+    const type = this.types[i]
+    let schema
+    if (typeof type === 'string') {
+      schema = extend({}, this.schema)
+      schema.type = type
+    } else {
+      schema = extend({}, this.schema, type)
+      if (type && type.required && Array.isArray(type.required) && this.schema.required && Array.isArray(this.schema.required)) {
+        schema.required = this.schema.required.concat(type.required)
+      }
+    }
+    return schema
+  }
+
+  _getValidator (i) {
+    if (!this.validators[i]) {
+      this.validators[i] = new Validator(this.jsoneditor, this._getTypeSchema(i), this._validatorOptions, this.defaults)
+    }
+    return this.validators[i]
+  }
+
   buildChildEditor (i) {
     const type = this.types[i]
     const holder = this.theme.getChildEditorHolder()
@@ -143,6 +165,19 @@ export class MultipleEditor extends AbstractEditor {
     })
 
     if (i !== this.type) holder.style.display = 'none'
+  }
+
+  getDefault () {
+    if (this.oneOf || this.anyOf) {
+      for (let i = 0; i < this.types.length; i++) {
+        const typeSchema = this.types[i]
+        if (typeSchema && Object.prototype.hasOwnProperty.call(typeSchema, 'default')) {
+          return typeSchema.default
+        }
+      }
+    }
+
+    return super.getDefault()
   }
 
   preBuild () {
@@ -245,29 +280,15 @@ export class MultipleEditor extends AbstractEditor {
     this.editor_holder = document.createElement('div')
     container.appendChild(this.editor_holder)
 
-    const validatorOptions = {}
+    this._validatorOptions = {}
     if (this.jsoneditor.options.custom_validators) {
-      validatorOptions.custom_validators = this.jsoneditor.options.custom_validators
+      this._validatorOptions.custom_validators = this.jsoneditor.options.custom_validators
     }
 
     this.switcher_options = this.theme.getSwitcherOptions(this.switcher)
     this.types.forEach((type, i) => {
       this.editors[i] = false
-
-      let schema
-
-      if (typeof type === 'string') {
-        schema = extend({}, this.schema)
-        schema.type = type
-      } else {
-        schema = extend({}, this.schema, type)
-
-        /* If we need to merge `required` arrays */
-        if (type.required && Array.isArray(type.required) && this.schema.required && Array.isArray(this.schema.required)) {
-          schema.required = this.schema.required.concat(type.required)
-        }
-      }
-      this.validators[i] = new Validator(this.jsoneditor, schema, validatorOptions, this.defaults)
+      this.validators[i] = null
     })
 
     this.jsoneditor.on('change', () => {
@@ -334,7 +355,8 @@ export class MultipleEditor extends AbstractEditor {
       match: 0,
       i: null
     }
-    this.validators.forEach((validator, i) => {
+    this.types.forEach((type, i) => {
+      const validator = this._getValidator(i)
       let fitTestResult = null
       if (typeof this.anyOf !== 'undefined' && this.anyOf) {
         fitTestResult = validator.fitTest(val)

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -1,5 +1,5 @@
 import { AbstractEditor } from '../editor.js'
-import { extend, hasOwnProperty, trigger } from '../utilities.js'
+import { hasOwnProperty, trigger } from '../utilities.js'
 import rules from './object.css.js'
 
 export class ObjectEditor extends AbstractEditor {
@@ -101,7 +101,7 @@ export class ObjectEditor extends AbstractEditor {
         const width = editor.options.hidden ? 0 : (editor.options.grid_columns || editor.getNumColumns())
         const offset = editor.options.hidden ? 0 : (editor.options.grid_offset || 0)
         const gridBreak = editor.options.hidden ? false : (editor.options.grid_break || false)
-        const height = editor.options.hidden ? 0 : editor.container.offsetHeight
+        const height = editor.options.hidden ? 0 : (editor.container.offsetHeight || 0)
 
         const column = {
           key,
@@ -146,7 +146,7 @@ export class ObjectEditor extends AbstractEditor {
         if (editor.property_removed) return
         let found = false
         const width = editor.options.hidden ? 0 : (editor.options.grid_columns || editor.getNumColumns())
-        const height = editor.options.hidden ? 0 : editor.container.offsetHeight
+        const height = editor.options.hidden ? 0 : (editor.container.offsetHeight || 0)
         /* See if the editor will fit in any of the existing rows first */
         for (let i = 0; i < rows.length; i++) {
           /* If the editor will fit in the row horizontally */
@@ -342,7 +342,7 @@ export class ObjectEditor extends AbstractEditor {
   getPropertySchema (key) {
     /* Schema declared directly in properties */
     let schema = this.schema.properties[key] || {}
-    schema = extend({}, schema)
+    schema = { ...schema }
     let matched = !!this.schema.properties[key]
 
     /* Any matching patternProperties should be merged in */
@@ -359,7 +359,7 @@ export class ObjectEditor extends AbstractEditor {
 
     /* Hasn't matched other rules, use additionalProperties schema */
     if (!matched && this.schema.additionalProperties && typeof this.schema.additionalProperties === 'object') {
-      schema = extend({}, this.schema.additionalProperties)
+      schema = { ...this.schema.additionalProperties }
     }
 
     return schema
@@ -815,15 +815,21 @@ export class ObjectEditor extends AbstractEditor {
       })
       /* Layout object editors in grid if needed */
     } else {
-      /* Initial layout */
-      this.layoutEditors()
-      /* Do it again now that we know the approximate heights of elements */
       this.layoutEditors()
     }
 
     if (this.schema.readOnly || this.schema.readonly) {
       this.disable()
     }
+  }
+
+  onContainerAttached () {
+    /* Re-run grid layout now that the container is in the live DOM and
+     * offsetHeight returns real values for height-based row grouping. */
+    if (this.format === 'grid') {
+      this.layoutEditors()
+    }
+    super.onContainerAttached()
   }
 
   deactivateNonRequiredProperties (recursive) {
@@ -1340,12 +1346,15 @@ export class ObjectEditor extends AbstractEditor {
   showValidationErrors (errors) {
     /* Get all the errors that pertain to this editor */
     const myErrors = []
-    const otherErrors = []
+    const childErrors = {}
+    const pathPrefix = this.path + '.'
     errors.forEach(error => {
       if (error.path === this.path) {
         myErrors.push(error)
-      } else {
-        otherErrors.push(error)
+      } else if (error.path.startsWith(pathPrefix)) {
+        const childKey = error.path.substring(pathPrefix.length).split('.')[0]
+        if (!childErrors[childKey]) childErrors[childKey] = []
+        childErrors[childKey].push(error)
       }
     })
 
@@ -1373,9 +1382,9 @@ export class ObjectEditor extends AbstractEditor {
       }
     }
 
-    /* Show errors for child editors */
-    Object.values(this.editors).forEach(editor => {
-      editor.showValidationErrors(otherErrors)
+    /* Show errors for child editors -- only pass relevant errors */
+    Object.entries(this.editors).forEach(([key, editor]) => {
+      editor.showValidationErrors(childErrors[key] || [])
     })
   }
 }

--- a/src/editors/signature.js
+++ b/src/editors/signature.js
@@ -76,12 +76,15 @@ export class SignatureEditor extends StringEditor {
       this.refreshValue()
 
       /* signature canvas will stretch to signatureContainer width */
+      canvas.style.display = 'block'
+      canvas.style.width = '100%'
       canvas.width = signatureContainer.offsetWidth
       if (this.options && this.options.canvas_height) {
         canvas.height = this.options.canvas_height
       } else {
         canvas.height = '300' /* Set to default height of 300px; */
       }
+      this.signatureCanvas = canvas
     } else {
       const message = document.createElement('p')
       message.innerHTML = 'Signature pad is not available, please include SignaturePad from https://github.com/szimek/signature_pad'
@@ -113,5 +116,18 @@ export class SignatureEditor extends StringEditor {
   destroy () {
     this.signaturePad.off()
     delete this.signaturePad
+  }
+
+  onContainerAttached () {
+    if (this.signatureCanvas) {
+      const container = this.signatureCanvas.parentElement
+      if (container) {
+        const width = container.offsetWidth
+        if (width) {
+          this.signatureCanvas.width = width
+        }
+      }
+    }
+    super.onContainerAttached()
   }
 }

--- a/src/schemaloader.js
+++ b/src/schemaloader.js
@@ -49,6 +49,9 @@ export class SchemaLoader {
      */
     this.refs_counter = 1
 
+    this._expandSchemaCache = new Map()
+    this._expandRefsCache = new Map()
+
     this._subSchema1 = {
       /* Version 3 `type` */
       type (schema) {
@@ -112,10 +115,10 @@ export class SchemaLoader {
       oneOf (schema, extended) {
         const tmp = extend({}, extended)
         delete tmp.oneOf
-        schema.oneOf.reduce((e, s, i) => {
-          e.oneOf[i] = this.extendSchemas(this.expandSchema(s), tmp)
-          return e
-        }, extended)
+        if (schema.default) {
+          delete tmp.default
+        }
+        extended.oneOf = schema.oneOf.map(s => this.extendSchemas(this.expandSchema(s), tmp))
         return extended
       }
     }
@@ -136,6 +139,7 @@ export class SchemaLoader {
   async load (schema, fetchUrl, location) {
     this.schema = schema
     await this._asyncloadExternalRefs(schema, fetchUrl, this._getFileBase(location), true)
+    this.onAllSchemasLoaded()
     return this.expandRefs(schema)
   }
 
@@ -147,9 +151,17 @@ export class SchemaLoader {
    * @returns {object} A JSON Schema with references expanded.
    */
   expandRefs (schema, recurseAllOf) {
-    const _schema = extend({}, schema)
+    if (!recurseAllOf) {
+      const cached = this._expandRefsCache.get(schema)
+      if (cached) return cached
+    }
 
-    if (!_schema.$ref) return _schema
+    const _schema = { ...schema }
+
+    if (!_schema.$ref) {
+      if (!recurseAllOf) this._expandRefsCache.set(schema, _schema)
+      return _schema
+    }
     // This split the ref to get the Json point if it exists
     // exemple #/counter/1#/definition/address +
     // [1] -> /counter/1
@@ -160,6 +172,7 @@ export class SchemaLoader {
       const sub = this.expandRecursivePointer(this.schema, refWithPointerSplit[1])
       const expandedSchema = this.extendSchemas(_schema, this.expandSchema(sub))
       delete expandedSchema.$ref
+      if (!recurseAllOf) this._expandRefsCache.set(schema, expandedSchema)
       return expandedSchema
     }
     const refObj = (refWithPointerSplit.length > 2)
@@ -180,11 +193,14 @@ export class SchemaLoader {
         allOf[key] = this.expandRefs(allOf[key], true)
       })
     }
+    let result
     if (refWithPointerSplit.length > 2) {
-      return this.extendSchemas(_schema, this.expandSchema(this.expandRecursivePointer(this.refs[ref], refWithPointerSplit[2])))
+      result = this.extendSchemas(_schema, this.expandSchema(this.expandRecursivePointer(this.refs[ref], refWithPointerSplit[2])))
     } else {
-      return this.extendSchemas(_schema, this.expandSchema(this.refs[ref]))
+      result = this.extendSchemas(_schema, this.expandSchema(this.refs[ref]))
     }
+    if (!recurseAllOf) this._expandRefsCache.set(schema, result)
+    return result
   }
 
   /**
@@ -215,13 +231,16 @@ export class SchemaLoader {
    * @returns {object} A JSON Schema with references expanded.
    */
   expandSchema (schema) {
+    const cached = this._expandSchemaCache.get(schema)
+    if (cached) return cached
+
     Object.entries(this._subSchema1).forEach(([key, func]) => {
       if (schema[key]) {
         func.call(this, schema)
       }
     })
 
-    let extended = extend({}, schema)
+    let extended = { ...schema }
 
     Object.entries(this._subSchema2).forEach(([key, func]) => {
       if (schema[key]) {
@@ -229,7 +248,9 @@ export class SchemaLoader {
       }
     })
 
-    return this.expandRefs(extended)
+    const result = this.expandRefs(extended)
+    this._expandSchemaCache.set(schema, result)
+    return result
   }
 
   _getRef (fetchUrl, refObj) {
@@ -373,117 +394,115 @@ export class SchemaLoader {
    */
   async _asyncloadExternalRefs (schema, fetchUrl, fileBase, firstIteration = false) {
     const refs = this._getExternalRefs(schema, fetchUrl, firstIteration)
-    let waiting = 0
-    // Loop into all schema references
-    for (const uri of Object.keys(refs)) {
-      if (typeof uri === 'undefined') continue
-      if (this.refs[uri]) continue
-      if (this._isUniformResourceName(uri)) {
-        this.refs[uri] = 'loading'
-        waiting++
-        const urnResolver = this.options.urn_resolver
-        let urn = uri
-        if (typeof urnResolver !== 'function') {
-          // eslint-disable-next-line no-console
-          console.log(`No "urn_resolver" callback defined to resolve "${urn}"`)
-          throw new Error(`Must set urn_resolver option to a callback to resolve ${urn}`)
-        }
-        // theoretically a URN can contain a JSON pointer
-        if (urn.indexOf('#') > 0) urn = urn.substr(0, urn.indexOf('#'))
-        let response
-        try {
-          let externalSchema
-          response = await urnResolver(urn)
-          try {
-            externalSchema = JSON.parse(response)
-          } catch (e) {
-            // eslint-disable-next-line no-console
-            console.log(e)
-            throw new Error(`Failed to parse external ref ${urn}`)
-          }
-          if (!(typeof externalSchema === 'boolean' || typeof externalSchema === 'object') || externalSchema === null || Array.isArray(externalSchema)) {
-            throw new Error(`External ref does not contain a valid schema - ${urn}`)
-          }
+    const pendingUris = Object.keys(refs).filter(uri => typeof uri !== 'undefined' && !this.refs[uri])
+    if (!pendingUris.length) return true
 
-          this.refs[uri] = externalSchema
+    const fetchTasks = pendingUris.map(uri => this._loadSingleRef(uri, fileBase))
+    await Promise.all(fetchTasks)
+  }
 
-          await this._asyncloadExternalRefs(externalSchema, uri, fileBase)
-        } catch (e) {
-          // eslint-disable-next-line no-console
-          console.log(e)
-          throw new Error(`Failed to parse external ref ${urn}`)
-        }
+  async _loadSingleRef (uri, fileBase) {
+    if (this._isUniformResourceName(uri)) {
+      return this._loadUrnRef(uri, fileBase)
+    }
+    if (!this.options.ajax) throw new Error(`Must set ajax option to true to load external ref ${uri}`)
+    return this._loadAjaxRef(uri, fileBase)
+  }
 
-        if (typeof response === 'boolean') {
-          throw new Error(`External ref does not contain a valid schema - ${urn}`)
-        }
-        continue
-      }
-      if (!this.options.ajax) throw new Error(`Must set ajax option to true to load external ref ${uri}`)
-      waiting++
-
-      let url = this._joinUrl(uri, fileBase)
-
+  async _loadUrnRef (uri, fileBase) {
+    this.refs[uri] = 'loading'
+    const urnResolver = this.options.urn_resolver
+    let urn = uri
+    if (typeof urnResolver !== 'function') {
+      // eslint-disable-next-line no-console
+      console.log(`No "urn_resolver" callback defined to resolve "${urn}"`)
+      throw new Error(`Must set urn_resolver option to a callback to resolve ${urn}`)
+    }
+    if (urn.indexOf('#') > 0) urn = urn.substr(0, urn.indexOf('#'))
+    let response
+    try {
       let externalSchema
-      if (this.options.ajax_cache_responses) {
-        const schemaFromCache = this.cacheGet(url)
-        if (schemaFromCache) {
-          externalSchema = schemaFromCache
-        }
+      response = await urnResolver(urn)
+      try {
+        externalSchema = JSON.parse(response)
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log(e)
+        throw new Error(`Failed to parse external ref ${urn}`)
       }
-
-      if (!externalSchema) {
-        const response = await new Promise(resolve => {
-          const r = new XMLHttpRequest()
-          if (this.options.ajaxCredentials) r.withCredentials = this.options.ajaxCredentials
-          r.overrideMimeType('application/json')
-          r.open('GET', url, true)
-          r.onload = () => {
-            resolve(r)
-          }
-          r.onerror = (e) => {
-            resolve(undefined)
-          }
-          r.send()
-        })
-        if (typeof response === 'undefined') throw new Error(`Failed to fetch ref via ajax - ${uri}`)
-        try {
-          externalSchema = JSON.parse(response.responseText)
-
-          this.onSchemaLoaded({
-            schema: externalSchema,
-            schemaUrl: url
-          })
-
-          if (this.options.ajax_cache_responses) {
-            this.cacheSet(url, externalSchema)
-          }
-        } catch (e) {
-          // eslint-disable-next-line no-console
-          console.log(e)
-          throw new Error(`Failed to parse external ref ${url}`)
-        }
-      }
-
       if (!(typeof externalSchema === 'boolean' || typeof externalSchema === 'object') || externalSchema === null || Array.isArray(externalSchema)) {
-        throw new Error(`External ref does not contain a valid schema - ${url}`)
+        throw new Error(`External ref does not contain a valid schema - ${urn}`)
       }
+
       this.refs[uri] = externalSchema
-      const newfileBase = this._getFileBaseFromFileLocation(url)
 
-      // Add leading slash.
-      if (url !== uri) {
-        const pathItems = url.split('/')
-        url = (uri.substr(0, 1) === '/' ? '/' : '') + pathItems.pop()
+      await this._asyncloadExternalRefs(externalSchema, uri, fileBase)
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log(e)
+      throw new Error(`Failed to parse external ref ${urn}`)
+    }
+
+    if (typeof response === 'boolean') {
+      throw new Error(`External ref does not contain a valid schema - ${urn}`)
+    }
+  }
+
+  async _loadAjaxRef (uri, fileBase) {
+    let url = this._joinUrl(uri, fileBase)
+
+    let externalSchema
+    if (this.options.ajax_cache_responses) {
+      const schemaFromCache = this.cacheGet(url)
+      if (schemaFromCache) {
+        externalSchema = schemaFromCache
       }
-      await this._asyncloadExternalRefs(externalSchema, url, newfileBase)
     }
 
-    if (!waiting) {
-      return true
+    if (!externalSchema) {
+      const response = await new Promise(resolve => {
+        const r = new XMLHttpRequest()
+        if (this.options.ajaxCredentials) r.withCredentials = this.options.ajaxCredentials
+        r.overrideMimeType('application/json')
+        r.open('GET', url, true)
+        r.onload = () => {
+          resolve(r)
+        }
+        r.onerror = (e) => {
+          resolve(undefined)
+        }
+        r.send()
+      })
+      if (typeof response === 'undefined') throw new Error(`Failed to fetch ref via ajax - ${uri}`)
+      try {
+        externalSchema = JSON.parse(response.responseText)
+
+        this.onSchemaLoaded({
+          schema: externalSchema,
+          schemaUrl: url
+        })
+
+        if (this.options.ajax_cache_responses) {
+          this.cacheSet(url, externalSchema)
+        }
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log(e)
+        throw new Error(`Failed to parse external ref ${url}`)
+      }
     }
 
-    this.onAllSchemasLoaded()
+    if (!(typeof externalSchema === 'boolean' || typeof externalSchema === 'object') || externalSchema === null || Array.isArray(externalSchema)) {
+      throw new Error(`External ref does not contain a valid schema - ${url}`)
+    }
+    this.refs[uri] = externalSchema
+    const newfileBase = this._getFileBaseFromFileLocation(url)
+
+    if (url !== uri) {
+      const pathItems = url.split('/')
+      url = (uri.substr(0, 1) === '/' ? '/' : '') + pathItems.pop()
+    }
+    await this._asyncloadExternalRefs(externalSchema, url, newfileBase)
   }
 
   onSchemaLoaded (payload) {}
@@ -491,8 +510,8 @@ export class SchemaLoader {
   onAllSchemasLoaded () {}
 
   extendSchemas (obj1, obj2) {
-    obj1 = extend({}, obj1)
-    obj2 = extend({}, obj2)
+    obj1 = { ...obj1 }
+    obj2 = { ...obj2 }
 
     const extended = {}
     const isRequiredOrDefaultProperties = (prop, val) => (prop === 'required' || prop === 'defaultProperties') && typeof val === 'object' && Array.isArray(val)

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -128,6 +128,9 @@ export function mergeDeep (target, ...sources) {
 }
 
 export function overwriteExistingProperties (obj1, obj2) {
+  if (!obj1 || typeof obj1 !== 'object') return obj1
+  if (!obj2 || typeof obj2 !== 'object') return obj1
+
   Object.keys(obj2).forEach(function (key) {
     if (key in obj1) {
       obj1[key] = obj2[key]

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,5 +1,5 @@
 import { ipValidator } from './validators/ip-validator.js'
-import { extend, hasOwnProperty } from './utilities.js'
+import { hasOwnProperty } from './utilities.js'
 
 export class Validator {
   constructor (jsoneditor, schema, options, defaults) {
@@ -688,7 +688,7 @@ export class Validator {
   }
 
   _getSchema (schema) {
-    return typeof schema === 'undefined' ? extend({}, this.jsoneditor.expandRefs(this.schema)) : schema
+    return typeof schema === 'undefined' ? { ...this.jsoneditor.expandRefs(this.schema) } : schema
   }
 
   validate (value) {
@@ -699,8 +699,8 @@ export class Validator {
     const errors = []
     path = path || this.jsoneditor.root.formname
 
-    /* Work on a copy of the schema */
-    schema = extend({}, this.jsoneditor.expandRefs(schema))
+    /* Work on a shallow copy of the expanded schema */
+    schema = { ...this.jsoneditor.expandRefs(schema) }
 
     /*
      * Type Agnostic Validation
@@ -754,7 +754,7 @@ export class Validator {
     const ref = document.location.origin + document.location.pathname + template(data)
 
     schema.links = schema.links.slice(0, m).concat(schema.links.slice(m + 1))
-    return extend({}, schema, this.jsoneditor.refs[ref])
+    return Object.assign({}, schema, this.jsoneditor.refs[ref])
   }
 
   _validateV3Required (schema, value, path) {

--- a/tests/codeceptjs/issues/issue-gh-1367_test.js
+++ b/tests/codeceptjs/issues/issue-gh-1367_test.js
@@ -7,5 +7,6 @@ Scenario('GitHub issue 1367 should remain fixed @issue-1367', async ({ I }) => {
   I.amOnPage('issues/issue-gh-1367.html')
   I.waitForElement('.je-ready')
   I.click('canvas')
+  I.wait(0.1)
   assert.match(await I.grabValueFrom('#value'), /base64/)
 })


### PR DESCRIPTION
Hello, we are using this library to render a fairly large schema, and in our case it became quite painful to wait until it finished loading. I used Claude Opus to optimize it and ran a few review loops. It significantly decreased the loading time (1.5s vs 13s on my machine in the Chrome browser). All tests pass, and our large schema renders correctly. I hope these improvements will be useful to you.

Below Summary of changes from my fellow friend Opus-4.6

---
This PR reduces initial render time and schema loading overhead through several targeted optimizations.

#### Off-screen DOM build (core.js, editor.js)
The editor tree is now built while root_container is detached from the live DOM and re-attached in a single appendChild call. This eliminates per-element reflows during construction. A building flag suppresses onChange() calls for the duration. The build block is wrapped in try/finally to guarantee root_container is always re-attached and building is always cleared, even if a build step throws.
A new onContainerAttached() lifecycle hook (empty stub on AbstractEditor) is called on all editors after re-attachment, allowing editors to perform layout-dependent initialization that requires a live DOM.

#### Schema loading (schemaloader.js)
External ref loading is parallelized using Promise.all instead of sequential await per URI. The monolithic _asyncloadExternalRefs loop is split into _loadSingleRef, _loadUrnRef, and _loadAjaxRef helpers to improve readability and testability. onAllSchemasLoaded() is moved to the top-level load() method so it fires exactly once after the full ref graph resolves, restoring the pre-existing single-fire guarantee.
expandSchema() and expandRefs() results are memoized by schema object identity (Map) to avoid re-expanding the same schema repeatedly. The oneOf handler is fixed to use map() instead of reduce() and to avoid clobbering the parent schema's default when merging.

#### Validation error dispatch (object.js, array.js)
showValidationErrors() in both ObjectEditor and ArrayEditor now pre-buckets errors by direct child key/index before passing them down. Previously the full error array was passed to every child, causing O(n×m) path comparisons. Each child now only receives errors that belong to it.

#### MultipleEditor lazy validators (multiple.js)
Validator instances are now created lazily via _getValidator(i) instead of being eagerly instantiated for all types at build time. _getTypeSchema(i) is extracted as a shared helper used by both _getValidator and buildChildEditor. A getDefault() override checks per-type default values in oneOf/anyOf schemas before falling back to the parent default.

#### SignatureEditor off-screen fix (signature.js)
The canvas reference is stored on this.signatureCanvas and initial CSS sizing (width: 100%) is applied at build time. A onContainerAttached() override reads the real container width after the DOM is live and updates canvas.width accordingly, fixing the canvas sizing regression caused by off-screen construction.

#### Grid layout fix (object.js)
ObjectEditor adds an onContainerAttached() override that re-runs layoutEditors() for grid-format objects after the container is in the live DOM. The existing diff-check inside layoutEditors() makes the second call a no-op when heights do not affect the computed layout.

#### Misc
- extend({}, ...) replaced with { ...obj } or Object.assign throughout affected files
- Null-guard added to overwriteExistingProperties in utilities.js
- E2E test for issue #1367 gains a short wait to accommodate the deferred canvas resize


| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | none
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️
