### PR TITLE
Fix: handle uuid in all types of duplicated item (nested, oneOf.)

### DIFF
--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -1,5 +1,5 @@
 import { AbstractEditor } from '../editor.js'
-import { extend, generateUUID, trigger } from '../utilities.js'
+import { extend, regenerateUUIDs, trigger } from '../utilities.js'
 import rules from './array.css.js'
 
 export class ArrayEditor extends AbstractEditor {
@@ -588,18 +588,7 @@ export class ArrayEditor extends AbstractEditor {
 
       value.forEach((row, j) => {
         if (j === i) {
-          let duplicatedRow = (typeof row === 'object' && row !== null) ? { ...row } : row
-          /* Force generation of new UUID if the item has been cloned. */
-          if (schema.items.type === 'string' && schema.items.format === 'uuid') {
-            duplicatedRow = generateUUID()
-          } else if (schema.items.type === 'object' && schema.items.properties) {
-            for (const key of Object.keys(duplicatedRow)) {
-              if (schema.items.properties && schema.items.properties[key] && schema.items.properties[key].format === 'uuid') {
-                duplicatedRow[key] = generateUUID()
-              }
-            }
-          }
-          value.push(duplicatedRow)
+          value.push(regenerateUUIDs(row, schema.items))
         }
       })
 

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -1,5 +1,5 @@
 import { ArrayEditor, supportDragDrop } from './array.js'
-import { extend, generateUUID, trigger } from '../utilities.js'
+import { extend, regenerateUUIDs, trigger } from '../utilities.js'
 
 export class TableEditor extends ArrayEditor {
   register () {
@@ -368,23 +368,7 @@ export class TableEditor extends ArrayEditor {
       const j = e.currentTarget.getAttribute('data-i') * 1
       const value = this.getValue()
 
-      let newValue = value[j]
-
-      /* On copy, recreate uuid if needed. */
-      if (schema.items.type === 'string' && schema.items.format === 'uuid') {
-        newValue = generateUUID()
-      } else if (schema.items.type === 'object' && schema.items.properties) {
-        value.forEach((row, i) => {
-          if (j === i) {
-            for (const key of Object.keys(row)) {
-              if (schema.items.properties && schema.items.properties[key] && schema.items.properties[key].format === 'uuid') {
-                newValue = Object.assign({}, value[j])
-                newValue[key] = generateUUID()
-              }
-            }
-          }
-        })
-      }
+      const newValue = regenerateUUIDs(value[j], schema.items)
 
       value.splice(j + 1, 0, newValue)
       this.setValue(value)

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -25,6 +25,20 @@ export function deepCopy (target) {
   return isPlainObject(target) ? extend({}, target) : Array.isArray(target) ? target.map(deepCopy) : target
 }
 
+function _schemaMatchesValue (value, schema) {
+  if (schema.oneOf || schema.anyOf) {
+    return (schema.oneOf || schema.anyOf).some(s => _schemaMatchesValue(value, s))
+  }
+  if (schema.type === 'object' && schema.properties) {
+    if (typeof value !== 'object' || value === null) return false
+    return Object.entries(schema.properties).every(([key, propSchema]) => {
+      if (!propSchema.enum) return true
+      return propSchema.enum.includes(value[key])
+    })
+  }
+  return true
+}
+
 export function regenerateUUIDs (value, schema) {
   if (!schema) return deepCopy(value)
 
@@ -44,6 +58,12 @@ export function regenerateUUIDs (value, schema) {
 
   if (schema.type === 'array' && schema.items) {
     return (Array.isArray(value) ? value : []).map(item => regenerateUUIDs(item, schema.items))
+  }
+
+  if (schema.oneOf || schema.anyOf) {
+    const candidates = schema.oneOf || schema.anyOf
+    const matching = candidates.find(s => _schemaMatchesValue(value, s))
+    return matching ? regenerateUUIDs(value, matching) : deepCopy(value)
   }
 
   return deepCopy(value)

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -25,6 +25,30 @@ export function deepCopy (target) {
   return isPlainObject(target) ? extend({}, target) : Array.isArray(target) ? target.map(deepCopy) : target
 }
 
+export function regenerateUUIDs (value, schema) {
+  if (!schema) return deepCopy(value)
+
+  if (schema.type === 'string' && schema.format === 'uuid') {
+    return generateUUID()
+  }
+
+  if (schema.type === 'object' && schema.properties) {
+    const newObj = extend({}, value)
+    for (const key of Object.keys(newObj)) {
+      if (schema.properties[key]) {
+        newObj[key] = regenerateUUIDs(newObj[key], schema.properties[key])
+      }
+    }
+    return newObj
+  }
+
+  if (schema.type === 'array' && schema.items) {
+    return (Array.isArray(value) ? value : []).map(item => regenerateUUIDs(item, schema.items))
+  }
+
+  return deepCopy(value)
+}
+
 export function extend (destination, ...args) {
   args.forEach(source => {
     if (source) {

--- a/tests/codeceptjs/editors/uuid_test.js
+++ b/tests/codeceptjs/editors/uuid_test.js
@@ -96,3 +96,13 @@ Scenario('table editor: copying an object should assign new uuids to its direct 
   assert.strictEqual((/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(copy)), true)
   assert.notStrictEqual(original, copy)
 })
+
+Scenario('array editor: copying a oneOf item should assign new uuids to its uuid fields @uuid', async ({ I }) => {
+  I.amOnPage('uuid.html')
+  I.click('Add uuid oneOf item')
+  const original = await I.grabValueFrom('[name="root[uuidOneOfArray][0][id]"]')
+  I.click('//button[contains(@class, "json-editor-btntype-copy") and @data-i="0"]')
+  const copy = await I.grabValueFrom('[name="root[uuidOneOfArray][1][id]"]')
+  assert.strictEqual((/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(copy)), true)
+  assert.notStrictEqual(original, copy)
+})

--- a/tests/codeceptjs/editors/uuid_test.js
+++ b/tests/codeceptjs/editors/uuid_test.js
@@ -46,3 +46,53 @@ Scenario('should have initial value matching uuid in arrays (table) of objects w
   const value1 = await I.grabValueFrom('[name="root[uuidObjectTable][1][uuid]"]')
   assert.strictEqual((/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value1)), true)
 })
+
+Scenario('array editor: copying a uuid string item should assign a different uuid to the copy @uuid', async ({ I }) => {
+  I.amOnPage('uuid.html')
+  I.click('Add uuid string array item')
+  const original = await I.grabValueFrom('[name="root[uuidStringArray][0]"]')
+  I.click('//button[contains(@class, "json-editor-btntype-copy") and @data-i="0"]')
+  const copy = await I.grabValueFrom('[name="root[uuidStringArray][1]"]')
+  assert.strictEqual((/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(copy)), true)
+  assert.notStrictEqual(original, copy)
+})
+
+Scenario('array editor: copying an object should assign new uuids to its direct uuid fields @uuid', async ({ I }) => {
+  I.amOnPage('uuid.html')
+  I.click('Add uuid object array item')
+  const original = await I.grabValueFrom('[name="root[uuidObjectArray][0][uuid]"]')
+  I.click('//button[contains(@class, "json-editor-btntype-copy") and @data-i="0"]')
+  const copy = await I.grabValueFrom('[name="root[uuidObjectArray][1][uuid]"]')
+  assert.strictEqual((/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(copy)), true)
+  assert.notStrictEqual(original, copy)
+})
+
+Scenario('array editor: copying an object should assign new uuids to uuid fields nested inside child objects @uuid', async ({ I }) => {
+  I.amOnPage('uuid.html')
+  I.click('Add uuid nested object array item')
+  const original = await I.grabValueFrom('[name="root[uuidNestedObjectArray][0][nested][id]"]')
+  I.click('//button[contains(@class, "json-editor-btntype-copy") and @data-i="0"]')
+  const copy = await I.grabValueFrom('[name="root[uuidNestedObjectArray][1][nested][id]"]')
+  assert.strictEqual((/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(copy)), true)
+  assert.notStrictEqual(original, copy)
+})
+
+Scenario('table editor: copying a uuid string item should assign a different uuid to the copy @uuid', async ({ I }) => {
+  I.amOnPage('uuid.html')
+  I.click('Add uuid string table item')
+  const original = await I.grabValueFrom('[name="root[uuidStringTable][0]"]')
+  I.click('//button[contains(@class, "json-editor-btntype-copy") and @data-i="0"]')
+  const copy = await I.grabValueFrom('[name="root[uuidStringTable][1]"]')
+  assert.strictEqual((/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(copy)), true)
+  assert.notStrictEqual(original, copy)
+})
+
+Scenario('table editor: copying an object should assign new uuids to its direct uuid fields @uuid', async ({ I }) => {
+  I.amOnPage('uuid.html')
+  I.click('Add uuid object table item')
+  const original = await I.grabValueFrom('[name="root[uuidObjectTable][0][uuid]"]')
+  I.click('//button[contains(@class, "json-editor-btntype-copy") and @data-i="0"]')
+  const copy = await I.grabValueFrom('[name="root[uuidObjectTable][1][uuid]"]')
+  assert.strictEqual((/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(copy)), true)
+  assert.notStrictEqual(original, copy)
+})

--- a/tests/pages/uuid.html
+++ b/tests/pages/uuid.html
@@ -92,6 +92,31 @@
               }
             }
           }
+        },
+        'uuidNestedObjectArray': {
+          'type': 'array',
+          'title': 'array of objects with nested uuid property',
+          'items': {
+            'title': 'uuid nested object array item',
+            'type': 'object',
+            'properties': {
+              'name': {
+                'type': 'string',
+                'title': 'name'
+              },
+              'nested': {
+                'type': 'object',
+                'title': 'nested',
+                'properties': {
+                  'id': {
+                    'type': 'string',
+                    'format': 'uuid',
+                    'title': 'id'
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/tests/pages/uuid.html
+++ b/tests/pages/uuid.html
@@ -93,6 +93,45 @@
             }
           }
         },
+        'uuidOneOfArray': {
+          'type': 'array',
+          'title': 'array of oneOf items with uuid',
+          'items': {
+            'title': 'uuid oneOf item',
+            'oneOf': [
+              {
+                'type': 'object',
+                'title': 'uuid oneOf typeA item',
+                'properties': {
+                  'discriminator': {
+                    'type': 'string',
+                    'enum': ['typeA'],
+                    'default': 'typeA'
+                  },
+                  'id': {
+                    'type': 'string',
+                    'format': 'uuid'
+                  }
+                }
+              },
+              {
+                'type': 'object',
+                'title': 'uuid oneOf typeB item',
+                'properties': {
+                  'discriminator': {
+                    'type': 'string',
+                    'enum': ['typeB'],
+                    'default': 'typeB'
+                  },
+                  'id': {
+                    'type': 'string',
+                    'format': 'uuid'
+                  }
+                }
+              }
+            ]
+          }
+        },
         'uuidNestedObjectArray': {
           'type': 'array',
           'title': 'array of objects with nested uuid property',


### PR DESCRIPTION
New PR to generate a new uuid when the duplicated object is a nested element, or in a oneOf/anyOf subdivision in the json-schema.
(It replaces those PR (that I have closed) : #1694 #1695 )

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | Continue to fix issue #1481 
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️