### PR TITLE
Fix base64 multi-file change event

### DIFF
--- a/src/editors/base64.js
+++ b/src/editors/base64.js
@@ -26,6 +26,7 @@ export class Base64Editor extends AbstractEditor {
       /* When all files have been processed, update the value of the editor */
       if (this.count === (this.total + this.current_item_index)) {
         this.arrayEditor.setValue(this.value)
+        this.arrayEditor.onChange(true)
       }
     })
   }

--- a/tests/unit/editors/base64.spec.js
+++ b/tests/unit/editors/base64.spec.js
@@ -1,0 +1,70 @@
+import { JSONEditor } from '../../../src/core'
+
+const waitForEditorChange = editor => new Promise(resolve => {
+  editor.on('change', resolve)
+})
+
+describe('Base64 Editor', () => {
+  let element
+  let editor
+
+  beforeEach(() => {
+    document.body.insertAdjacentHTML(
+      'afterbegin',
+      '<div id="fixture"></div>')
+    element = document.getElementById('fixture')
+  })
+
+  afterEach(() => {
+    editor.destroy()
+  })
+
+  it('triggers change after reading multiple files into an array', async () => {
+    editor = new JSONEditor(element, {
+      schema: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            file: {
+              type: 'string',
+              media: {
+                binaryEncoding: 'base64'
+              },
+              options: {
+                multiple: true
+              }
+            }
+          }
+        }
+      },
+      startval: [
+        {
+          file: ''
+        }
+      ]
+    })
+    await new Promise(resolve => editor.on('ready', resolve))
+
+    const base64Editor = editor.getEditor('root.0.file')
+    const change = waitForEditorChange(editor)
+
+    Object.defineProperty(base64Editor.uploader, 'files', {
+      configurable: true,
+      value: [
+        new File(['one'], 'one.txt', { type: 'text/plain' }),
+        new File(['two'], 'two.txt', { type: 'text/plain' })
+      ]
+    })
+    base64Editor.uploader.dispatchEvent(new Event('change', {
+      bubbles: true
+    }))
+
+    await change
+
+    const value = editor.getValue()
+    expect(value.length).toBe(2)
+    expect(value[0].file).toMatch(/^data:text\/plain;base64,/)
+    expect(value[1].file).toMatch(/^data:text\/plain;base64,/)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1672.

When the base64 editor reads multiple files inside an array item, it updates the parent array editor after all `FileReader` callbacks finish. That path did not bubble a change event to the root `JSONEditor`, so consumers listening with `editor.on('change', ...)` were not notified.

This change bubbles the event from the updated array editor after `setValue()` completes.

## Tests

- `git diff --check`
- `npm run eslint`
- `npx eslint -c ./.eslintrc tests/unit/editors/base64.spec.js`
- `npm run test-headless` (`300 SUCCESS`)