### PR TITLE
Bring the Tailwind theme up to par with Bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed #1636. multiselect obstructed editor format "table"
 - Fixed #1559 and #1621 field dependent on false should now display
+- Fixed #1612, adding `for` attributes to labels in the Tailwind theme
 
 ### 2.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Fixed #1636. multiselect obstructed editor format "table"
 - Fixed #1559 and #1621 field dependent on false should now display
 - Fixed #1612, adding `for` attributes to labels in the Tailwind theme
+- Fixed #1698, using Tailwind classes to hide elements
+
 
 ### 2.15.2
 

--- a/src/themes/tailwind.js
+++ b/src/themes/tailwind.js
@@ -207,7 +207,7 @@ export class tailwindTheme extends AbstractTheme {
     return el
   }
 
-  getFormControl (label, input, description, infoText) {
+  getFormControl (label, input, description, infoText, formName) {
     const group = document.createElement('div')
     group.classList.add('form-group', 'mb-1', 'w-full')
     if (label) {
@@ -236,6 +236,16 @@ export class tailwindTheme extends AbstractTheme {
     }
 
     if (description) group.appendChild(description)
+
+    if (input.tagName.toLowerCase() !== 'div' && input && label && formName) {
+      label.setAttribute('for', formName)
+      input.setAttribute('id', formName)
+    }
+
+    if (input.tagName.toLowerCase() !== 'div' && input && description) {
+      description.setAttribute('id', formName + '-description')
+      input.setAttribute('aria-describedby', formName + '-description')
+    }
 
     return group
   }

--- a/src/themes/tailwind.js
+++ b/src/themes/tailwind.js
@@ -250,6 +250,28 @@ export class tailwindTheme extends AbstractTheme {
     return group
   }
 
+  getHiddenLabel (text) {
+    const el = document.createElement('label')
+    el.textContent = text
+    el.classList.add('sr-only')
+    return el
+  }
+
+  visuallyHidden (element) {
+    if (!element) {
+      return
+    }
+
+    element.classList.add('hidden')
+  }
+
+  getHiddenText (text) {
+    const el = document.createElement('span')
+    el.textContent = text
+    el.classList.add('sr-only')
+    return el
+  }
+
   getHeaderButtonHolder () {
     const el = this.getButtonHolder()
     el.classList.add('text-sm')

--- a/tests/pages/themes.html
+++ b/tests/pages/themes.html
@@ -18,6 +18,7 @@
           <option value='bootstrap3'>Bootstrap 3</option>
           <option value='bootstrap4'>Bootstrap 4</option>
           <option value='bootstrap5'>Bootstrap 5</option>
+          <option value='tailwind'>Tailwind</option>
           <option value='html'>HTML</option>
           <option value='spectre'>Spectre</option>
         </select>
@@ -478,6 +479,7 @@
         bootstrap3: 'https://netdna.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css',
         bootstrap4: 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css',
         bootstrap5: 'https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css',
+        tailwind:   'https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css',
         foundation3: 'https://cdnjs.cloudflare.com/ajax/libs/foundation/3.2.5/stylesheets/foundation.css',
         foundation4: 'https://cdnjs.cloudflare.com/ajax/libs/foundation/4.3.2/css/foundation.min.css',
         foundation5: 'https://cdnjs.cloudflare.com/ajax/libs/foundation/5.5.3/css/foundation.min.css',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Is backward-compatible?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #1612, #1698
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️

The Tailwind theme was in need of some love on the accessibility front.

This Pull Request fixes two issues on that theme:

## #1612 - Missing `for` attribute in labels

Based on the Bootstrap themes, we now add `for` and `aria-describedby` attributes to labels, ensuring that label clicks work, and screen readers have a correct mapping of labels and fields.

## #1698 - Using `style` elements to hide fields

Also based on the Bootstrap themes, we now use Tailwind classes to hide elements instead of falling back to the default implementation (that modifies the `style` attribute).